### PR TITLE
AWS DynamoDB check for default KMS key

### DIFF
--- a/provider/aws/dynamodb/dynamodb.go
+++ b/provider/aws/dynamodb/dynamodb.go
@@ -17,6 +17,8 @@ type ServerSideEncryption struct {
 	KMSKeyID types.StringValue
 }
 
+const DefaultKMSKeyID = "alias/aws/dynamodb"
+
 func (c *DAXCluster) GetMetadata() *types.Metadata {
 	return &c.Metadata
 }

--- a/rules/aws/dynamodb/table_customer_key.go
+++ b/rules/aws/dynamodb/table_customer_key.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"github.com/aquasecurity/defsec/provider"
+	"github.com/aquasecurity/defsec/provider/aws/dynamodb"
 	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/severity"
 	"github.com/aquasecurity/defsec/state"
@@ -20,13 +21,13 @@ var CheckTableCustomerKey = rules.Register(
 		Links: []string{
 			"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html",
 		},
-		Terraform:   &rules.EngineMetadata{
-            GoodExamples:        terraformTableCustomerKeyGoodExamples,
-            BadExamples:         terraformTableCustomerKeyBadExamples,
-            Links:               terraformTableCustomerKeyLinks,
-            RemediationMarkdown: terraformTableCustomerKeyRemediationMarkdown,
-        },
-        Severity: severity.Low,
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformTableCustomerKeyGoodExamples,
+			BadExamples:         terraformTableCustomerKeyBadExamples,
+			Links:               terraformTableCustomerKeyLinks,
+			RemediationMarkdown: terraformTableCustomerKeyRemediationMarkdown,
+		},
+		Severity: severity.Low,
 	},
 	func(s *state.State) (results rules.Results) {
 		for _, cluster := range s.AWS.DynamoDB.DAXClusters {
@@ -36,6 +37,11 @@ var CheckTableCustomerKey = rules.Register(
 			if cluster.ServerSideEncryption.KMSKeyID.IsEmpty() {
 				results.Add(
 					"Cluster encryption does not use a customer-managed KMS key.",
+					cluster.ServerSideEncryption.KMSKeyID,
+				)
+			} else if cluster.ServerSideEncryption.KMSKeyID.EqualTo(dynamodb.DefaultKMSKeyID) {
+				results.Add(
+					"Cluster encryption explicitly uses the default KMS key.",
 					cluster.ServerSideEncryption.KMSKeyID,
 				)
 			} else {


### PR DESCRIPTION
Old logic in tfsec checks whether the kms key attribute explicitly uses the default value. This check is missing in the defsec equivalent. 
See [tfsec check](https://github.com/aquasecurity/tfsec/blob/master/internal/app/tfsec/rules/aws/dynamodb/table_customer_key_rule.go#L88) and [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#kms_key_arn) 