### PR TITLE
AWS SSM check for default key

### DIFF
--- a/provider/aws/ssm/ssm.go
+++ b/provider/aws/ssm/ssm.go
@@ -11,6 +11,8 @@ type Secret struct {
 	KMSKeyID types.StringValue
 }
 
+const DefaultKMSKeyID = "alias/aws/secretsmanager"
+
 func (v *Secret) GetMetadata() *types.Metadata {
 	return &v.Metadata
 }

--- a/rules/aws/ssm/secret_use_customer_key.go
+++ b/rules/aws/ssm/secret_use_customer_key.go
@@ -2,6 +2,7 @@ package ssm
 
 import (
 	"github.com/aquasecurity/defsec/provider"
+	"github.com/aquasecurity/defsec/provider/aws/ssm"
 	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/severity"
 	"github.com/aquasecurity/defsec/state"
@@ -20,25 +21,31 @@ var CheckSecretUseCustomerKey = rules.Register(
 		Links: []string{
 			"https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html#asm-encrypt",
 		},
-		Terraform:   &rules.EngineMetadata{
-            GoodExamples:        terraformSecretUseCustomerKeyGoodExamples,
-            BadExamples:         terraformSecretUseCustomerKeyBadExamples,
-            Links:               terraformSecretUseCustomerKeyLinks,
-            RemediationMarkdown: terraformSecretUseCustomerKeyRemediationMarkdown,
-        },
-        CloudFormation:   &rules.EngineMetadata{
-            GoodExamples:        cloudFormationSecretUseCustomerKeyGoodExamples,
-            BadExamples:         cloudFormationSecretUseCustomerKeyBadExamples,
-            Links:               cloudFormationSecretUseCustomerKeyLinks,
-            RemediationMarkdown: cloudFormationSecretUseCustomerKeyRemediationMarkdown,
-        },
-        Severity: severity.Low,
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformSecretUseCustomerKeyGoodExamples,
+			BadExamples:         terraformSecretUseCustomerKeyBadExamples,
+			Links:               terraformSecretUseCustomerKeyLinks,
+			RemediationMarkdown: terraformSecretUseCustomerKeyRemediationMarkdown,
+		},
+		CloudFormation: &rules.EngineMetadata{
+			GoodExamples:        cloudFormationSecretUseCustomerKeyGoodExamples,
+			BadExamples:         cloudFormationSecretUseCustomerKeyBadExamples,
+			Links:               cloudFormationSecretUseCustomerKeyLinks,
+			RemediationMarkdown: cloudFormationSecretUseCustomerKeyRemediationMarkdown,
+		},
+		Severity: severity.Low,
 	},
 	func(s *state.State) (results rules.Results) {
 		for _, secret := range s.AWS.SSM.Secrets {
 			if secret.KMSKeyID.IsEmpty() {
 				results.Add(
 					"Secret is not encrypted with a customer managed key.",
+					&secret,
+					secret.KMSKeyID,
+				)
+			} else if secret.KMSKeyID.EqualTo(ssm.DefaultKMSKeyID) {
+				results.Add(
+					"Secret explicitly uses the default key.",
 					&secret,
 					secret.KMSKeyID,
 				)


### PR DESCRIPTION
Old logic in tfsec checks whether the kms key attribute explicitly uses the default value. This check is missing in the defsec equivalent.

[Tfsec check](https://github.com/aquasecurity/tfsec/blob/master/internal/app/tfsec/rules/aws/ssm/secret_use_customer_key_rule.go#L49)
[Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret#kms_key_id)