### PR TITLE
AWS KMS update key usage check

### DIFF
--- a/rules/aws/kms/auto_rotate_keys.go
+++ b/rules/aws/kms/auto_rotate_keys.go
@@ -21,17 +21,17 @@ var CheckAutoRotateKeys = rules.Register(
 		Links: []string{
 			"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html",
 		},
-		Terraform:   &rules.EngineMetadata{
-            GoodExamples:        terraformAutoRotateKeysGoodExamples,
-            BadExamples:         terraformAutoRotateKeysBadExamples,
-            Links:               terraformAutoRotateKeysLinks,
-            RemediationMarkdown: terraformAutoRotateKeysRemediationMarkdown,
-        },
-        Severity: severity.Medium,
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformAutoRotateKeysGoodExamples,
+			BadExamples:         terraformAutoRotateKeysBadExamples,
+			Links:               terraformAutoRotateKeysLinks,
+			RemediationMarkdown: terraformAutoRotateKeysRemediationMarkdown,
+		},
+		Severity: severity.Medium,
 	},
 	func(s *state.State) (results rules.Results) {
 		for _, key := range s.AWS.KMS.Keys {
-			if key.Usage.NotEqualTo(kms.KeyUsageSignAndVerify) {
+			if key.Usage.EqualTo(kms.KeyUsageSignAndVerify) {
 				continue
 			}
 			if key.RotationEnabled.IsFalse() {


### PR DESCRIPTION
In the [old logic](https://github.com/aquasecurity/tfsec/blob/master/internal/app/tfsec/rules/aws/kms/auto_rotate_keys_rule.go#L34) in tfsec the `enable_key_rotation` attribute is checked only when the `key_usage` attribute **doesn't** equal `SIGN_VERIFY`. In defsec however, the opposite is done. 