### PR TITLE
AWS EKS only check CIDRs when public access is enabled

### DIFF
--- a/rules/aws/eks/no_public_cluster_access_to_cidr.go
+++ b/rules/aws/eks/no_public_cluster_access_to_cidr.go
@@ -23,16 +23,19 @@ var CheckNoPublicClusterAccessToCidr = rules.Register(
 		Links: []string{
 			"https://docs.aws.amazon.com/eks/latest/userguide/create-public-private-vpc.html",
 		},
-		Terraform:   &rules.EngineMetadata{
-            GoodExamples:        terraformNoPublicClusterAccessToCidrGoodExamples,
-            BadExamples:         terraformNoPublicClusterAccessToCidrBadExamples,
-            Links:               terraformNoPublicClusterAccessToCidrLinks,
-            RemediationMarkdown: terraformNoPublicClusterAccessToCidrRemediationMarkdown,
-        },
-        Severity: severity.Critical,
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformNoPublicClusterAccessToCidrGoodExamples,
+			BadExamples:         terraformNoPublicClusterAccessToCidrBadExamples,
+			Links:               terraformNoPublicClusterAccessToCidrLinks,
+			RemediationMarkdown: terraformNoPublicClusterAccessToCidrRemediationMarkdown,
+		},
+		Severity: severity.Critical,
 	},
 	func(s *state.State) (results rules.Results) {
 		for _, cluster := range s.AWS.EKS.Clusters {
+			if cluster.PublicAccessEnabled.IsFalse() {
+				continue
+			}
 			for _, accessCidr := range cluster.PublicAccessCIDRs {
 				if cidr.IsPublic(accessCidr.Value()) {
 					results.Add(


### PR DESCRIPTION
In the [old tfsec logic ](https://github.com/aquasecurity/tfsec/blob/master/internal/app/tfsec/rules/aws/eks/no_public_cluster_access_to_cidr_rule.go#L52) CIDRs are checked only when the public access attribute is enabled. This bit is added now in defsec.