### PR TITLE
AWS VPC check default desc & make protocol string

### DIFF
--- a/provider/aws/vpc/vpc.go
+++ b/provider/aws/vpc/vpc.go
@@ -44,7 +44,7 @@ type NetworkACLRule struct {
 	types.Metadata
 	Type     types.StringValue
 	Action   types.StringValue
-	Protocol types.IntValue
+	Protocol types.StringValue
 	CIDRs    []types.StringValue
 }
 

--- a/rules/aws/vpc/add_description_to_security_group.go
+++ b/rules/aws/vpc/add_description_to_security_group.go
@@ -22,19 +22,19 @@ Simplifies auditing, debugging, and managing security groups.`,
 		Links: []string{
 			"https://www.cloudconformity.com/knowledge-base/aws/EC2/security-group-rules-description.html",
 		},
-		Terraform:   &rules.EngineMetadata{
-            GoodExamples:        terraformAddDescriptionToSecurityGroupGoodExamples,
-            BadExamples:         terraformAddDescriptionToSecurityGroupBadExamples,
-            Links:               terraformAddDescriptionToSecurityGroupLinks,
-            RemediationMarkdown: terraformAddDescriptionToSecurityGroupRemediationMarkdown,
-        },
-        CloudFormation:   &rules.EngineMetadata{
-            GoodExamples:        cloudFormationAddDescriptionToSecurityGroupGoodExamples,
-            BadExamples:         cloudFormationAddDescriptionToSecurityGroupBadExamples,
-            Links:               cloudFormationAddDescriptionToSecurityGroupLinks,
-            RemediationMarkdown: cloudFormationAddDescriptionToSecurityGroupRemediationMarkdown,
-        },
-        Severity: severity.Low,
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformAddDescriptionToSecurityGroupGoodExamples,
+			BadExamples:         terraformAddDescriptionToSecurityGroupBadExamples,
+			Links:               terraformAddDescriptionToSecurityGroupLinks,
+			RemediationMarkdown: terraformAddDescriptionToSecurityGroupRemediationMarkdown,
+		},
+		CloudFormation: &rules.EngineMetadata{
+			GoodExamples:        cloudFormationAddDescriptionToSecurityGroupGoodExamples,
+			BadExamples:         cloudFormationAddDescriptionToSecurityGroupBadExamples,
+			Links:               cloudFormationAddDescriptionToSecurityGroupLinks,
+			RemediationMarkdown: cloudFormationAddDescriptionToSecurityGroupRemediationMarkdown,
+		},
+		Severity: severity.Low,
 	},
 	func(s *state.State) (results rules.Results) {
 		for _, group := range s.AWS.VPC.SecurityGroups {
@@ -44,6 +44,12 @@ Simplifies auditing, debugging, and managing security groups.`,
 			if group.Description.IsEmpty() {
 				results.Add(
 					"Security group does not have a description.",
+					&group,
+					group.Description,
+				)
+			} else if group.Description.EqualTo("Managed by Terraform") {
+				results.Add(
+					"Security group explicitly uses the default description.",
 					&group,
 					group.Description,
 				)

--- a/rules/aws/vpc/no_excessive_port_access.go
+++ b/rules/aws/vpc/no_excessive_port_access.go
@@ -20,24 +20,24 @@ var CheckNoExcessivePortAccess = rules.Register(
 		Links: []string{
 			"https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html",
 		},
-		Terraform:   &rules.EngineMetadata{
-            GoodExamples:        terraformNoExcessivePortAccessGoodExamples,
-            BadExamples:         terraformNoExcessivePortAccessBadExamples,
-            Links:               terraformNoExcessivePortAccessLinks,
-            RemediationMarkdown: terraformNoExcessivePortAccessRemediationMarkdown,
-        },
-        CloudFormation:   &rules.EngineMetadata{
-            GoodExamples:        cloudFormationNoExcessivePortAccessGoodExamples,
-            BadExamples:         cloudFormationNoExcessivePortAccessBadExamples,
-            Links:               cloudFormationNoExcessivePortAccessLinks,
-            RemediationMarkdown: cloudFormationNoExcessivePortAccessRemediationMarkdown,
-        },
-        Severity: severity.Critical,
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformNoExcessivePortAccessGoodExamples,
+			BadExamples:         terraformNoExcessivePortAccessBadExamples,
+			Links:               terraformNoExcessivePortAccessLinks,
+			RemediationMarkdown: terraformNoExcessivePortAccessRemediationMarkdown,
+		},
+		CloudFormation: &rules.EngineMetadata{
+			GoodExamples:        cloudFormationNoExcessivePortAccessGoodExamples,
+			BadExamples:         cloudFormationNoExcessivePortAccessBadExamples,
+			Links:               cloudFormationNoExcessivePortAccessLinks,
+			RemediationMarkdown: cloudFormationNoExcessivePortAccessRemediationMarkdown,
+		},
+		Severity: severity.Critical,
 	},
 	func(s *state.State) (results rules.Results) {
 		for _, acl := range s.AWS.VPC.NetworkACLs {
 			for _, rule := range acl.Rules {
-				if rule.Protocol.EqualTo(-1) {
+				if rule.Protocol.EqualTo("-1") || rule.Protocol.EqualTo("all") {
 					results.Add(
 						"Network ACL rule allows access using ALL ports.",
 						&rule,


### PR DESCRIPTION
Add check for default value on security group.
Network ACL rule protocol can also be a string (see [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule)) so change `Protocol` field in struct.
Add check for string version of default value (`"all"`)