### PR TITLE
Add check for Digital Ocean's Kubernetes auto_upgrade option.

### DIFF
--- a/avd_docs/digitalocean/compute/AVD-DIG-0006/Terraform.md
+++ b/avd_docs/digitalocean/compute/AVD-DIG-0006/Terraform.md
@@ -1,0 +1,29 @@
+Set `auto_upgrade` to `true` and set `maintenance_policy` to a time window when you know the workloads of your cluster is not peaking.
+
+```hcl
+data "digitalocean_kubernetes_versions" "example" {
+  version_prefix = "1.22."
+}
+
+resource "digitalocean_kubernetes_cluster" "foo" {
+  name         = "foo"
+  region       = "nyc1"
+  auto_upgrade = true
+  version      = data.digitalocean_kubernetes_versions.example.latest_version
+
+  # remember to actively set this
+  maintenance_policy {
+    start_time  = "04:00"
+    day         = "sunday"
+  }
+
+  node_pool {
+    name       = "default"
+    size       = "s-1vcpu-2gb"
+    node_count = 3
+  }
+}
+```
+
+#### Remediation Links
+ - https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#auto_upgrade

--- a/avd_docs/digitalocean/compute/AVD-DIG-0006/docs.md
+++ b/avd_docs/digitalocean/compute/AVD-DIG-0006/docs.md
@@ -1,0 +1,14 @@
+### Enable auto upgrade for your Kubernetes cluster
+
+Always running the latest version of Kubernetes ensures always having the latest security patches for your cluster.
+
+### Impact
+
+Not patching your Kubernetes cluster can leave it a vulnerable target for pen-testers. Consider enabling auto upgrades, possibly with a deterministic maintenance window.
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://docs.digitalocean.com/products/kubernetes/resources/best-practices/#enable-automatic-upgrades
+

--- a/provider/digitalocean/compute/compute.go
+++ b/provider/digitalocean/compute/compute.go
@@ -3,14 +3,21 @@ package compute
 import "github.com/aquasecurity/defsec/types"
 
 type Compute struct {
-	Firewalls     []Firewall
-	LoadBalancers []LoadBalancer
-	Droplets      []Droplet
+	Firewalls          []Firewall
+	LoadBalancers      []LoadBalancer
+	Droplets           []Droplet
+	KubernetesClusters []KubernetesCluster
 }
 
 type Firewall struct {
 	OutboundRules []OutboundFirewallRule
 	InboundRules  []InboundFirewallRule
+}
+
+type KubernetesCluster struct {
+	types.Metadata
+	SurgeUpgrade types.BoolValue
+	AutoUpgrade  types.BoolValue
 }
 
 type LoadBalancer struct {
@@ -32,6 +39,10 @@ type InboundFirewallRule struct {
 type Droplet struct {
 	types.Metadata
 	SSHKeys []types.StringValue
+}
+
+func (kc KubernetesCluster) GetMetadata() *types.Metadata {
+	return &kc.Metadata
 }
 
 func (d Droplet) GetMetadata() *types.Metadata {

--- a/rules/digitalocean/compute/auto_upgrade_no_maintenance_policy.go
+++ b/rules/digitalocean/compute/auto_upgrade_no_maintenance_policy.go
@@ -1,0 +1,42 @@
+package compute
+
+import (
+	"github.com/aquasecurity/defsec/provider"
+	"github.com/aquasecurity/defsec/rules"
+	"github.com/aquasecurity/defsec/severity"
+	"github.com/aquasecurity/defsec/state"
+)
+
+var CheckAutoUpgrade = rules.Register(
+	rules.Rule{
+		AVDID:       "AVD-DIG-0006",
+		Provider:    provider.DigitalOceanProvider,
+		Service:     "compute",
+		ShortCode:   "kubernetes-auto-upgrades-not-enabled",
+		Summary:     "Kubernetes clusters should be auto-upgraded to ensure that they always contain the latest security patches.",
+		Impact:      "Not running the latest security patches on your Kubernetes cluster can make it a target for penetration.",
+		Resolution:  "Set maintenace policy deterministically when auto upgrades are enabled",
+		Explanation: ``,
+		Links: []string{
+			"https://docs.digitalocean.com/products/kubernetes/resources/best-practices/",
+		},
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformKubernetesClusterAutoUpgradeGoodExample,
+			BadExamples:         terraformKubernetesClusterAutoUpgradeBadExample,
+			Links:               terraformKubernetesClusterAutoUpgradeLinks,
+			RemediationMarkdown: terraformEnforceHttpsRemediationMarkdown,
+		},
+		Severity: severity.Critical,
+	},
+	func(s *state.State) (results rules.Results) {
+		for _, kc := range s.DigitalOcean.Compute.KubernetesClusters {
+			if kc.AutoUpgrade.IsFalse() {
+				results.Add(
+					"Kubernetes Cluster does not enable auto upgrades enabled",
+					kc.AutoUpgrade,
+				)
+			}
+		}
+		return
+	},
+)

--- a/rules/digitalocean/compute/auto_upgrade_no_maintenance_policy.tf.go
+++ b/rules/digitalocean/compute/auto_upgrade_no_maintenance_policy.tf.go
@@ -1,0 +1,45 @@
+package compute
+
+var terraformKubernetesClusterAutoUpgradeBadExample = []string{
+	`
+resource "digitalocean_kubernetes_cluster" "foo" {
+	name    	 = "foo"
+	region  	 = "nyc1"
+	version 	 = "1.20.2-do.0"
+	auto_upgrade = false
+
+	node_pool {
+		name       = "autoscale-worker-pool"
+		size       = "s-2vcpu-2gb"
+		auto_scale = true
+		min_nodes  = 1
+		max_nodes  = 5
+	}
+}
+`,
+}
+
+var terraformKubernetesClusterAutoUpgradeGoodExample = []string{
+	`
+resource "digitalocean_kubernetes_cluster" "foo" {
+	name    	 = "foo"
+	region  	 = "nyc1"
+	version 	 = "1.20.2-do.0"
+	auto_upgrade = true
+
+	node_pool {
+		name       = "autoscale-worker-pool"
+		size       = "s-2vcpu-2gb"
+		auto_scale = true
+		min_nodes  = 1
+		max_nodes  = 5
+	}
+}
+`,
+}
+
+var terraformKubernetesClusterAutoUpgradeLinks = []string{
+	`https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#auto-upgrade-example`,
+}
+
+var terraformKubernetesAutoUpgradeMarkdown = ``


### PR DESCRIPTION
Again, I'm not really sure about tests, and if `tfsec` is just the place to add this stuff. It feels a bit weird adding code without tests :man_shrugging: 