### PR TITLE
feat: Added a rule to detect publicly accessible settings in `openstack_networking_secgroup_rule_v2`

### DIFF
--- a/loader/rules.go
+++ b/loader/rules.go
@@ -65,5 +65,6 @@ import (
 	_ "github.com/aquasecurity/defsec/rules/google/storage"
 	_ "github.com/aquasecurity/defsec/rules/kubernetes/network"
 	_ "github.com/aquasecurity/defsec/rules/openstack/compute"
+	_ "github.com/aquasecurity/defsec/rules/openstack/networking"
 	_ "github.com/aquasecurity/defsec/rules/oracle/compute"
 )

--- a/provider/openstack/openstack.go
+++ b/provider/openstack/openstack.go
@@ -4,13 +4,24 @@ import "github.com/aquasecurity/defsec/types"
 
 type OpenStack struct {
 	types.Metadata
-	Compute Compute
+	Compute    Compute
+	Networking Networking
 }
 
 type Compute struct {
 	types.Metadata
 	Instances []Instance
 	Firewall  Firewall
+}
+
+type Networking struct {
+	types.Metadata
+	Direction      types.StringValue
+	Ethertype      types.StringValue
+	Protocol       types.StringValue
+	PortRangeMin   types.IntValue
+	PortRangeMax   types.IntValue
+	RemoteIPPrefix types.StringValue
 }
 
 type Firewall struct {
@@ -31,4 +42,8 @@ type Rule struct {
 type Instance struct {
 	types.Metadata
 	AdminPassword types.StringValue
+}
+
+func (n Networking) IsIngress() bool {
+	return n.Direction.Value() == "ingress"
 }

--- a/rules/openstack/networking/no_public_access_security_group.go
+++ b/rules/openstack/networking/no_public_access_security_group.go
@@ -1,0 +1,45 @@
+package networking
+
+import (
+	"github.com/aquasecurity/defsec/cidr"
+	"github.com/aquasecurity/defsec/provider"
+	"github.com/aquasecurity/defsec/rules"
+	"github.com/aquasecurity/defsec/severity"
+	"github.com/aquasecurity/defsec/state"
+)
+
+var CheckNoPublicAccessSecurityGroup = rules.Register(
+	rules.Rule{
+		AVDID:       "AVD-OPNSTK-0003",
+		Provider:    provider.OpenStackProvider,
+		Service:     "network",
+		ShortCode:   "no-public-access-sg",
+		Summary:     "A Security Group rule allows traffic from the public internet",
+		Impact:      "Exposure of infrastructure to the public internet",
+		Resolution:  "Employ more restrictive Security Group rules",
+		Explanation: `Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.`,
+		Links:       []string{},
+		Terraform: &rules.EngineMetadata{
+			GoodExamples:        terraformNoPublicAccessSGGoodExamples,
+			BadExamples:         terraformNoPublicAccessSGBadExamples,
+			Links:               terraformNoPublicAccessSGLinks,
+			RemediationMarkdown: terraformNoPublicAccessSGRemediationMarkdown,
+		},
+		Severity: severity.Medium,
+	},
+	func(s *state.State) (results rules.Results) {
+		if s.OpenStack.Networking.IsUnmanaged() {
+			return
+		}
+
+		if s.OpenStack.Networking.IsIngress() && cidr.IsPublic(s.OpenStack.Networking.RemoteIPPrefix.Value()) {
+			results.Add(
+				"Security Group allows public ingress",
+				s.OpenStack.Networking.RemoteIPPrefix,
+			)
+		} else {
+			results.AddPassed(s.OpenStack.Networking)
+		}
+		return
+	},
+)

--- a/rules/openstack/networking/no_public_access_security_group.tf.go
+++ b/rules/openstack/networking/no_public_access_security_group.tf.go
@@ -1,0 +1,35 @@
+package networking
+
+var terraformNoPublicAccessSGGoodExamples = []string{
+	`
+resource "openstack_networking_secgroup_rule_v2" "ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  security_group_id = openstack_networking_secgroup_v2.ssh.id
+  remote_ip_prefix  = "10.0.1.1/24"
+}
+ 			`,
+}
+
+var terraformNoPublicAccessSGBadExamples = []string{
+	`
+resource "openstack_networking_secgroup_rule_v2" "ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  security_group_id = openstack_networking_secgroup_v2.ssh.id
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+ 			`,
+}
+
+var terraformNoPublicAccessSGLinks = []string{
+	`https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_secgroup_rule_v2`,
+}
+
+var terraformNoPublicAccessSGRemediationMarkdown = ``

--- a/rules/openstack/networking/no_public_access_security_group_test.go
+++ b/rules/openstack/networking/no_public_access_security_group_test.go
@@ -1,0 +1,64 @@
+package networking
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/provider/openstack"
+	"github.com/aquasecurity/defsec/rules"
+	"github.com/aquasecurity/defsec/state"
+	"github.com/aquasecurity/defsec/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckNoPublicAccessSecurityGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    openstack.Networking
+		expected bool
+	}{
+		{
+			name: "SecrityGroup rule with public ingress addresse",
+			input: openstack.Networking{
+				Metadata:       types.NewTestMetadata(),
+				Direction:      types.String("ingress", types.NewTestMetadata()),
+				Ethertype:      types.String("IPv4", types.NewTestMetadata()),
+				Protocol:       types.String("tcp", types.NewTestMetadata()),
+				PortRangeMin:   types.Int(22, types.NewTestMetadata()),
+				PortRangeMax:   types.Int(22, types.NewTestMetadata()),
+				RemoteIPPrefix: types.String("0.0.0.0/0", types.NewTestMetadata()),
+			},
+			expected: true,
+		},
+		{
+			name: "SecrityGroup rule with private ingress addresse",
+			input: openstack.Networking{
+				Metadata:       types.NewTestMetadata(),
+				Direction:      types.String("ingress", types.NewTestMetadata()),
+				Ethertype:      types.String("IPv4", types.NewTestMetadata()),
+				Protocol:       types.String("tcp", types.NewTestMetadata()),
+				PortRangeMin:   types.Int(22, types.NewTestMetadata()),
+				PortRangeMax:   types.Int(22, types.NewTestMetadata()),
+				RemoteIPPrefix: types.String("10.0.1.1/24", types.NewTestMetadata()),
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var testState state.State
+			testState.OpenStack.Networking = test.input
+			results := CheckNoPublicAccessSecurityGroup.Evaluate(&testState)
+			var found bool
+			for _, result := range results {
+				if result.Status() != rules.StatusPassed && result.Rule().LongID() == CheckNoPublicAccessSecurityGroup.Rule().LongID() {
+					found = true
+				}
+			}
+			if test.expected {
+				assert.True(t, found, "Rule should have been found")
+			} else {
+				assert.False(t, found, "Rule should not have been found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
In the OpenStack Security Group, add a rule that can detect settings that can be accessed externally.

ref: https://github.com/aquasecurity/tfsec/issues/1301