### PR TITLE
fix: Ensure files are always parsed in the same order

### DIFF
--- a/parsers/terraform/parser/parser.go
+++ b/parsers/terraform/parser/parser.go
@@ -168,19 +168,14 @@ func (p *parser) ParseDirectory(fullPath string) error {
 	}
 
 	var paths []string
-
 	for _, info := range fileInfos {
 		info = resolveSymlink(fullPath, info)
 		if info.IsDir() {
 			continue
 		}
-
 		currentFilePath := filepath.Join(fullPath, info.Name())
-
 		paths = append(paths, currentFilePath)
-
 	}
-
 	sort.Strings(paths)
 	for _, path := range paths {
 		if err := p.ParseFile(path); err != nil {

--- a/parsers/terraform/parser/parser.go
+++ b/parsers/terraform/parser/parser.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -166,6 +167,8 @@ func (p *parser) ParseDirectory(fullPath string) error {
 		return err
 	}
 
+	var paths []string
+
 	for _, info := range fileInfos {
 		info = resolveSymlink(fullPath, info)
 		if info.IsDir() {
@@ -173,13 +176,21 @@ func (p *parser) ParseDirectory(fullPath string) error {
 		}
 
 		currentFilePath := filepath.Join(fullPath, info.Name())
-		if err := p.ParseFile(currentFilePath); err != nil {
+
+		paths = append(paths, currentFilePath)
+
+	}
+
+	sort.Strings(paths)
+	for _, path := range paths {
+		if err := p.ParseFile(path); err != nil {
 			if p.stopOnHCLError {
 				return err
 			}
 			continue
 		}
 	}
+
 	p.debug("Added directory %s.", fullPath)
 	return nil
 }


### PR DESCRIPTION
Relates to https://github.com/aquasecurity/tfsec/issues/1495