### PR TITLE
feat: add support for AKS role_based_access_control_enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 vendor/
 .idea/
 *.iml
+.vscode/

--- a/adapters/terraform/azure/container/adapt.go
+++ b/adapters/terraform/azure/container/adapt.go
@@ -74,11 +74,16 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 		}
 	}
 
+	// azurerm < 2.99.0
 	roleBasedAccessControlBlock := resource.GetBlock("role_based_access_control")
 	if roleBasedAccessControlBlock.IsNotNil() {
 		rbEnabledAttr := roleBasedAccessControlBlock.GetAttribute("enabled")
 		cluster.RoleBasedAccessControl.Metadata = roleBasedAccessControlBlock.GetMetadata()
 		cluster.RoleBasedAccessControl.Enabled = rbEnabledAttr.AsBoolValueOrDefault(false, roleBasedAccessControlBlock)
+	} else {
+		// azurerm >= 2.99.0
+		roleBasedAccessControlEnabledAttr := resource.GetAttribute("role_based_access_control_enabled")
+		cluster.RoleBasedAccessControl.Enabled = roleBasedAccessControlEnabledAttr.AsBoolValueOrDefault(false, resource)
 	}
 	return cluster
 }

--- a/adapters/terraform/azure/container/adapt_test.go
+++ b/adapters/terraform/azure/container/adapt_test.go
@@ -66,7 +66,7 @@ func Test_adaptCluster(t *testing.T) {
 			},
 		},
 		{
-			name: "defaults with a new syntax",
+			name: "rbac with a new syntax",
 			terraform: `
 			resource "azurerm_kubernetes_cluster" "example" {
 				role_based_access_control_enabled = true

--- a/adapters/terraform/azure/container/adapt_test.go
+++ b/adapters/terraform/azure/container/adapt_test.go
@@ -66,6 +66,33 @@ func Test_adaptCluster(t *testing.T) {
 			},
 		},
 		{
+			name: "defaults with a new syntax",
+			terraform: `
+			resource "azurerm_kubernetes_cluster" "example" {
+				role_based_access_control_enabled = true
+			}
+`,
+			expected: container.KubernetesCluster{
+				Metadata: types.NewTestMetadata(),
+				NetworkProfile: container.NetworkProfile{
+					Metadata:      types.NewTestMetadata(),
+					NetworkPolicy: types.String("", types.NewTestMetadata()),
+				},
+				EnablePrivateCluster: types.Bool(false, types.NewTestMetadata()),
+				AddonProfile: container.AddonProfile{
+					Metadata: types.NewTestMetadata(),
+					OMSAgent: container.OMSAgent{
+						Metadata: types.NewTestMetadata(),
+						Enabled:  types.Bool(false, types.NewTestMetadata()),
+					},
+				},
+				RoleBasedAccessControl: container.RoleBasedAccessControl{
+					Metadata: types.NewTestMetadata(),
+					Enabled:  types.Bool(true, types.NewTestMetadata()),
+				},
+			},
+		},
+		{
 			name: "defaults",
 			terraform: `
 			resource "azurerm_kubernetes_cluster" "example" {

--- a/rules/azure/container/use_rbac_permissions.tf.go
+++ b/rules/azure/container/use_rbac_permissions.tf.go
@@ -2,21 +2,29 @@ package container
 
 var terraformUseRbacPermissionsGoodExamples = []string{
 	`
+ // azurerm < 2.99.0
  resource "azurerm_kubernetes_cluster" "good_example" {
  	role_based_access_control {
  		enabled = true
  	}
  }
+
+ // azurerm >= 2.99.0
+ role_based_access_control_enabled = true
  `,
 }
 
 var terraformUseRbacPermissionsBadExamples = []string{
 	`
+ // azurerm < 2.99.0
  resource "azurerm_kubernetes_cluster" "bad_example" {
  	role_based_access_control {
  		enabled = false
  	}
  }
+
+ // azurerm >= 2.99.0
+ role_based_access_control_enabled = false
  `,
 }
 


### PR DESCRIPTION
## Suggested change

Recently, azurerm [2.99.0](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v2.99.0) was published, which, in preparation for 3.0, brought some syntax changes, one of which is listed below:
***
"Data Source: `azurerm_kubernetes_cluster` - deprecated the `role_based_access_control` block in favour of `azure_active_directory_role_based_access_control` and `role_based_access_control_enabled` properties (https://github.com/hashicorp/terraform-provider-azurerm/issues/15584)"
***

This PR adds support for `role_based_access_control_enabled`.

## Implementation details

Previously, RBAC was configured through a separate block, whereas now it's just a field.
I saw that `KubernetesCluster` struct has, e.g., `EnablePrivateCluster        types.BoolValue`, so it may seem logical to bring something like `EnableRoleBasedAccessControl        types.BoolValue`, but that would overcomplicate code and would require changes in rules.
IMO, it's better to slightly adjust adapter to store the value of `role_based_access_control_enabled` in `cluster.RoleBasedAccessControl.Enabled` as before. I was only concerned about `cluster.RoleBasedAccessControl.Metadata` as the code does not update the field in the context of the new syntax, though I can't think of any negative effects in regards to that.

Closes #400