### PR TITLE
feat: add download count for the modules in the stats

### DIFF
--- a/parsers/terraform/parser/parser.go
+++ b/parsers/terraform/parser/parser.go
@@ -39,9 +39,10 @@ type Metrics struct {
 		ParseDuration  time.Duration
 	}
 	Counts struct {
-		Blocks  int
-		Modules int
-		Files   int
+		Blocks          int
+		Modules         int
+		ModuleDownloads int
+		Files           int
 	}
 }
 

--- a/parsers/terraform/parser/resolvers/registry.go
+++ b/parsers/terraform/parser/resolvers/registry.go
@@ -7,13 +7,21 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver"
 )
 
-type registryResolver struct{}
+type registryResolver struct {
+	client *http.Client
+}
 
-var Registry = &registryResolver{}
+var Registry = &registryResolver{
+	client: &http.Client{
+		// give it a maximum 5 seconds to resolve the module
+		Timeout: time.Second * 5,
+	},
+}
 
 type moduleVersions struct {
 	Modules []struct {
@@ -89,7 +97,7 @@ func (r *registryResolver) Resolve(ctx context.Context, opt Options) (downloadPa
 		req.Header.Set("X-Terraform-Version", opt.Version)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return "", true, err
 	}

--- a/scanners/terraform/scanner.go
+++ b/scanners/terraform/scanner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquasecurity/defsec/rego"
 
 	"github.com/aquasecurity/defsec/parsers/terraform/parser"
+	"github.com/aquasecurity/defsec/parsers/terraform/parser/resolvers"
 	"github.com/aquasecurity/defsec/rules"
 	"github.com/aquasecurity/defsec/scanners/terraform/executor"
 )
@@ -139,6 +140,8 @@ func (s *Scanner) Scan() (rules.Results, Metrics, error) {
 
 		allResults = append(allResults, results...)
 	}
+
+	metrics.Parser.Counts.ModuleDownloads = resolvers.Remote.GetDownloadCount()
 
 	metrics.Timings.Total += metrics.Parser.Timings.DiskIODuration
 	metrics.Timings.Total += metrics.Parser.Timings.ParseDuration


### PR DESCRIPTION
```

  timings
  ──────────────────────────────────────────
  disk i/o             165.732µs
  parsing              6.891576905s
  adaptation           80.161µs
  checks               8.628285ms
  total                6.900451083s

  counts
  ──────────────────────────────────────────
  modules downloaded   1
  modules processed    6
  blocks processsed    175
  files read           16

  results
  ──────────────────────────────────────────
  passed               1
  ignored              0
  critical             0
  high                 1
  medium               1
  low                  1

  1 passed, 3 potential problem(s) detected.

```


Signed-off-by: Owen Rumney <owen@owenrumney.co.uk>

