### PR TITLE
feat: Add OptionWithPolicyReaders option to kubernetes scanner

### DIFF
--- a/pkg/rego/scanner_test.go
+++ b/pkg/rego/scanner_test.go
@@ -29,7 +29,7 @@ deny {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -60,7 +60,7 @@ deny {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -102,7 +102,7 @@ exception[ns] {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -140,7 +140,7 @@ exception[rules] {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -175,7 +175,7 @@ deny_evil {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -207,7 +207,7 @@ deny[msg] {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -246,7 +246,7 @@ deny[res] {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -289,7 +289,7 @@ deny[res] {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -344,7 +344,7 @@ deny[res] {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -394,7 +394,7 @@ deny {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -429,7 +429,7 @@ deny {
 	scanner := NewScanner()
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, "policies"),
+		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{

--- a/pkg/scanners/cloudformation/scanner.go
+++ b/pkg/scanners/cloudformation/scanner.go
@@ -73,7 +73,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		regoOpts = append(regoOpts, rego.OptionWithTrace(s.traceWriter))
 	}
 	regoScanner := rego.NewScanner(regoOpts...)
-	if err := regoScanner.LoadPolicies(true, srcFS, s.policyDirs...); err != nil {
+	if err := regoScanner.LoadPolicies(true, srcFS, s.policyDirs, nil); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/dockerfile/scanner.go
+++ b/pkg/scanners/dockerfile/scanner.go
@@ -100,7 +100,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		regoOpts = append(regoOpts, rego.OptionWithTrace(s.traceWriter))
 	}
 	regoScanner := rego.NewScanner(regoOpts...)
-	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs...); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs, nil); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/kubernetes/option.go
+++ b/pkg/scanners/kubernetes/option.go
@@ -17,6 +17,12 @@ func OptionWithPolicyDirs(paths ...string) func(s *Scanner) {
 	}
 }
 
+func OptionWithPolicyReaders(readers ...io.Reader) func(s *Scanner) {
+	return func(s *Scanner) {
+		s.policyReaders = readers
+	}
+}
+
 func OptionWithDataDirs(paths ...string) func(s *Scanner) {
 	return func(s *Scanner) {
 		s.dataDirs = paths

--- a/pkg/scanners/kubernetes/scanner.go
+++ b/pkg/scanners/kubernetes/scanner.go
@@ -27,6 +27,7 @@ type Scanner struct {
 	debugWriter      io.Writer
 	traceWriter      io.Writer
 	policyDirs       []string
+	policyReaders    []io.Reader
 	dataDirs         []string
 	policyNamespaces []string
 	regoScanner      *rego.Scanner
@@ -65,7 +66,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		regoOpts = append(regoOpts, rego.OptionWithTrace(s.traceWriter))
 	}
 	regoScanner := rego.NewScanner(regoOpts...)
-	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs...); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/kubernetes/scanner_test.go
+++ b/pkg/scanners/kubernetes/scanner_test.go
@@ -309,3 +309,26 @@ spec:
 
 	assert.Greater(t, len(results.GetFailed()), 0)
 }
+
+func Test_FileScanWithPolicyReader(t *testing.T) {
+
+	results, err := NewScanner(OptionWithPolicyReaders(strings.NewReader(`package defsec
+
+deny[msg] {
+  msg = "fail"
+}
+`))).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(`
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: hello-cpu-limit
+spec: 
+  containers: 
+  - command: ["sh", "-c", "echo 'Hello' && sleep 1h"]
+    image: busybox
+    name: hello
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(results.GetFailed()))
+}

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -88,7 +88,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		regoOpts = append(regoOpts, rego.OptionWithTrace(s.traceWriter))
 	}
 	regoScanner := rego.NewScanner(regoOpts...)
-	if err := regoScanner.LoadPolicies(true, srcFS, s.policyDirs...); err != nil {
+	if err := regoScanner.LoadPolicies(true, srcFS, s.policyDirs, nil); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner


### PR DESCRIPTION
Adds the `OptionWithPolicyReaders` option to the k8s scanner to allow rego policies to be dynamically loaded from one or more `io.Reader` interfaces:

```go
results, err := NewScanner(OptionWithPolicyReaders(strings.NewReader(`package defsec

deny[msg] {
  msg = "fail"
}
`))).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(`
apiVersion: v1
kind: Pod
metadata: 
  name: hello-cpu-limit
spec: 
  containers: 
  - command: ["sh", "-c", "echo 'Hello' && sleep 1h"]
    image: busybox
    name: hello
`))
```