### PR TITLE
feat(cf): Add support for AES256 enryption for s3 bucket in cloudformation

### DIFF
--- a/internal/adapters/cloudformation/aws/s3/bucket.go
+++ b/internal/adapters/cloudformation/aws/s3/bucket.go
@@ -99,7 +99,9 @@ func getEncryption(r *parser.Resource, _ parser.FileContext) s3.Encryption {
 
 	if encryptProps := r.GetProperty("BucketEncryption.ServerSideEncryptionConfiguration"); encryptProps.IsNotNil() {
 		for _, rule := range encryptProps.AsList() {
-			if kmsKeyProp := rule.GetProperty("ServerSideEncryptionByDefault.KMSMasterKeyID"); !kmsKeyProp.IsEmpty() && kmsKeyProp.IsString() {
+			if algo := rule.GetProperty("ServerSideEncryptionByDefault.SSEAlgorithm"); algo.EqualTo("AES256") {
+				encryption.Enabled = types.Bool(true, algo.Metadata())
+			} else if kmsKeyProp := rule.GetProperty("ServerSideEncryptionByDefault.KMSMasterKeyID"); !kmsKeyProp.IsEmpty() && kmsKeyProp.IsString() {
 				encryption.KMSKeyId = kmsKeyProp.AsStringValue()
 			}
 			if encryption.Enabled.IsFalse() {


### PR DESCRIPTION
Resolves #452

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>