### PR TITLE
Allow to skip checking required files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/defsec
 
-go 1.17
+go 1.18
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -187,7 +187,6 @@ github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3st
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -702,7 +701,6 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/google/wire v0.4.0/go.mod h1:ngWDr9Qvq3yZA10YrxfyGELY/AFWGVpy9c1LTRi1EoU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
-github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -781,7 +779,6 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
@@ -1041,7 +1038,6 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzBgXmE=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.1.1 h1:JVUO0cEhG8bvEWIxsRmURY4u7wBZUTgdh4zikkkiPM8=
 github.com/owenrumney/go-sarif/v2 v2.1.1/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=
@@ -1478,7 +1474,6 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211111083644-e5c967477495/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d h1:1n1fc535VhN8SYtD4cDUyNlfpAF2ROMM9+11equK3hs=
 golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/scanners/cloudformation/option.go
+++ b/pkg/scanners/cloudformation/option.go
@@ -1,6 +1,10 @@
 package cloudformation
 
-import "io"
+import (
+	"io"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/parser"
+)
 
 // Option - scanner options for passing arguments into the scanner
 type Option func(s *Scanner)
@@ -57,5 +61,11 @@ func OptionWithPolicyNamespaces(namespaces ...string) func(s *Scanner) {
 func OptionWithTrace(w io.Writer) Option {
 	return func(s *Scanner) {
 		s.traceWriter = w
+	}
+}
+
+func OptionWithParser(parser *parser.Parser) Option {
+	return func(s *Scanner) {
+		s.parser = parser
 	}
 }

--- a/pkg/scanners/cloudformation/parser/option.go
+++ b/pkg/scanners/cloudformation/parser/option.go
@@ -13,6 +13,12 @@ func OptionWithDebugWriter(w io.Writer) Option {
 	}
 }
 
+func OptionWithSkipRequired(skipRequired bool) Option {
+	return func(p *Parser) {
+		p.skipRequired = skipRequired
+	}
+}
+
 func ProvidedParametersOption(parameters string) Option {
 
 	pairs := strings.Split(parameters, ",")

--- a/pkg/scanners/cloudformation/parser/parser.go
+++ b/pkg/scanners/cloudformation/parser/parser.go
@@ -15,8 +15,9 @@ import (
 )
 
 type Parser struct {
-	parameters  map[string]Parameter
-	debugWriter io.Writer
+	parameters   map[string]Parameter
+	debugWriter  io.Writer
+	skipRequired bool
 }
 
 func New(options ...Option) *Parser {
@@ -68,6 +69,9 @@ func (p *Parser) ParseFS(ctx context.Context, target fs.FS, dir string) (FileCon
 }
 
 func (p *Parser) Required(fs fs.FS, path string) bool {
+	if p.skipRequired {
+		return true
+	}
 
 	var unmarshalFunc func([]byte, interface{}) error
 

--- a/pkg/scanners/dockerfile/option.go
+++ b/pkg/scanners/dockerfile/option.go
@@ -2,6 +2,8 @@ package dockerfile
 
 import (
 	"io"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/dockerfile/parser"
 )
 
 type Option func(s *Scanner)
@@ -35,5 +37,11 @@ func OptionWithPolicyNamespaces(namespaces ...string) func(s *Scanner) {
 func OptionWithTrace(w io.Writer) Option {
 	return func(s *Scanner) {
 		s.traceWriter = w
+	}
+}
+
+func OptionWithParser(parser *parser.Parser) Option {
+	return func(s *Scanner) {
+		s.parser = parser
 	}
 }

--- a/pkg/scanners/dockerfile/parser/option.go
+++ b/pkg/scanners/dockerfile/parser/option.go
@@ -1,0 +1,9 @@
+package parser
+
+type Option func(p *Parser)
+
+func OptionWithSkipRequired(skipRequired bool) Option {
+	return func(p *Parser) {
+		p.skipRequired = skipRequired
+	}
+}

--- a/pkg/scanners/dockerfile/parser/parser.go
+++ b/pkg/scanners/dockerfile/parser/parser.go
@@ -14,13 +14,19 @@ import (
 	"golang.org/x/xerrors"
 )
 
-type Parser struct{}
+type Parser struct {
+	skipRequired bool
+}
 
 const requiredFile = "Dockerfile"
 
 // New creates a new Dockerfile parser
-func New() *Parser {
-	return &Parser{}
+func New(options ...Option) *Parser {
+	p := &Parser{}
+	for _, option := range options {
+		option(p)
+	}
+	return p
 }
 
 func (p *Parser) ParseFS(ctx context.Context, target fs.FS, path string) (map[string]*dockerfile.Dockerfile, error) {
@@ -65,6 +71,9 @@ func (p *Parser) ParseFile(_ context.Context, fs fs.FS, path string) (*dockerfil
 }
 
 func (p *Parser) Required(path string) bool {
+	if p.skipRequired {
+		return true
+	}
 	base := filepath.Base(path)
 	ext := filepath.Ext(base)
 	if strings.EqualFold(base, requiredFile+ext) {

--- a/pkg/scanners/kubernetes/option.go
+++ b/pkg/scanners/kubernetes/option.go
@@ -1,6 +1,10 @@
 package kubernetes
 
-import "io"
+import (
+	"io"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/kubernetes/parser"
+)
 
 type Option func(s *Scanner)
 
@@ -39,5 +43,11 @@ func OptionWithPolicyNamespaces(namespaces ...string) func(s *Scanner) {
 func OptionWithTrace(w io.Writer) Option {
 	return func(s *Scanner) {
 		s.traceWriter = w
+	}
+}
+
+func OptionWithParser(p *parser.Parser) Option {
+	return func(s *Scanner) {
+		s.parser = p
 	}
 }

--- a/pkg/scanners/kubernetes/parser/option.go
+++ b/pkg/scanners/kubernetes/parser/option.go
@@ -1,0 +1,9 @@
+package parser
+
+type Option func(p *Parser)
+
+func OptionWithSkipRequired(skipRequired bool) Option {
+	return func(p *Parser) {
+		p.skipRequired = skipRequired
+	}
+}

--- a/pkg/scanners/kubernetes/scanner.go
+++ b/pkg/scanners/kubernetes/scanner.go
@@ -31,12 +31,14 @@ type Scanner struct {
 	dataDirs         []string
 	policyNamespaces []string
 	regoScanner      *rego.Scanner
+	parser           *parser.Parser
 	sync.Mutex
 }
 
 func NewScanner(options ...Option) *Scanner {
 	s := &Scanner{
 		debugWriter: ioutil.Discard,
+		parser:      parser.New(),
 	}
 	for _, opt := range options {
 		opt(s)
@@ -90,7 +92,7 @@ func (s *Scanner) ScanReader(ctx context.Context, filename string, reader io.Rea
 
 func (s *Scanner) ScanFS(ctx context.Context, target fs.FS, dir string) (scan.Results, error) {
 
-	k8sFiles, err := parser.New().ParseFS(ctx, target, dir)
+	k8sFiles, err := s.parser.ParseFS(ctx, target, dir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
There are 2 benefits:
- If the given fs.FS contains only target files, skipping `Required()` will bring better performance.
- In a way, it allows to override the behavior of `Required()`. The caller can decide which files are passed to `ScanFS()`.