### PR TITLE
fix(rego): Add filenames to passed results during rego checks

### DIFF
--- a/pkg/rego/scanner.go
+++ b/pkg/rego/scanner.go
@@ -178,6 +178,7 @@ func (s *Scanner) applyRule(ctx context.Context, namespace string, rule string, 
 		} else if ignored {
 			var result regoResult
 			result.Filepath = input.Path
+			result.Managed = true
 			results.AddIgnored(result)
 			continue
 		}
@@ -189,6 +190,7 @@ func (s *Scanner) applyRule(ctx context.Context, namespace string, rule string, 
 		if len(ruleResults) == 0 {
 			var result regoResult
 			result.Filepath = input.Path
+			result.Managed = true
 			results.AddPassed(result)
 			continue
 		}
@@ -207,6 +209,7 @@ func (s *Scanner) applyRuleCombined(ctx context.Context, namespace string, rule 
 		for _, input := range inputs {
 			var result regoResult
 			result.Filepath = input.Path
+			result.Managed = true
 			results.AddIgnored(result)
 		}
 		return results, nil

--- a/pkg/rego/scanner_test.go
+++ b/pkg/rego/scanner_test.go
@@ -44,6 +44,8 @@ deny {
 	assert.Equal(t, 1, len(results.GetFailed()))
 	assert.Equal(t, 0, len(results.GetPassed()))
 	assert.Equal(t, 0, len(results.GetIgnored()))
+
+	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
 }
 
 func Test_RegoScanning_Allow(t *testing.T) {
@@ -75,6 +77,8 @@ deny {
 	assert.Equal(t, 0, len(results.GetFailed()))
 	assert.Equal(t, 1, len(results.GetPassed()))
 	assert.Equal(t, 0, len(results.GetIgnored()))
+
+	assert.Equal(t, "/evil.lol", results.GetPassed()[0].Metadata().Range().GetFilename())
 }
 
 func Test_RegoScanning_Namespace_Exception(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>