### PR TITLE
feat: Add per-result tracing option to rego scanning

### DIFF
--- a/pkg/rego/exceptions.go
+++ b/pkg/rego/exceptions.go
@@ -17,7 +17,7 @@ func (s *Scanner) isIgnored(ctx context.Context, namespace string, ruleName stri
 
 func (s *Scanner) isNamespaceIgnored(ctx context.Context, namespace string, input interface{}) (bool, error) {
 	exceptionQuery := fmt.Sprintf("data.namespace.exceptions.exception[_] == %q", namespace)
-	result, err := s.runQuery(ctx, exceptionQuery, input, true)
+	result, _, err := s.runQuery(ctx, exceptionQuery, input, true)
 	if err != nil {
 		return false, fmt.Errorf("query namespace exceptions: %w", err)
 	}
@@ -26,7 +26,7 @@ func (s *Scanner) isNamespaceIgnored(ctx context.Context, namespace string, inpu
 
 func (s *Scanner) isRuleIgnored(ctx context.Context, namespace string, ruleName string, input interface{}) (bool, error) {
 	exceptionQuery := fmt.Sprintf("data.%s.exception[_][_] == %q", namespace, removeRulePrefix(ruleName))
-	result, err := s.runQuery(ctx, exceptionQuery, input, true)
+	result, _, err := s.runQuery(ctx, exceptionQuery, input, true)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/rego/option.go
+++ b/pkg/rego/option.go
@@ -18,6 +18,13 @@ func OptionWithTrace(w io.Writer) func(s *Scanner) {
 	}
 }
 
+// OptionWithPerResultTracing - sets up tracing on a per-result basis with no main stream
+func OptionWithPerResultTracing() func(s *Scanner) {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}
+
 func OptionWithPolicyNamespaces(includeDefaults bool, namespaces ...string) func(s *Scanner) {
 	return func(s *Scanner) {
 		if !includeDefaults {

--- a/pkg/rego/result.go
+++ b/pkg/rego/result.go
@@ -99,7 +99,7 @@ func parseLineNumber(raw interface{}) int {
 	return n
 }
 
-func (s *Scanner) convertResults(set rego.ResultSet, filepath string, namespace string, rule string) scan.Results {
+func (s *Scanner) convertResults(set rego.ResultSet, filepath string, namespace string, rule string, traces []string) scan.Results {
 	var results scan.Results
 	for _, result := range set {
 		for _, expression := range result.Expressions {
@@ -112,7 +112,7 @@ func (s *Scanner) convertResults(set rego.ResultSet, filepath string, namespace 
 				if regoResult.Message == "" {
 					regoResult.Message = fmt.Sprintf("Rego policy rule: %s.%s", namespace, rule)
 				}
-				results.AddRego(regoResult.Message, namespace, rule, regoResult)
+				results.AddRego(regoResult.Message, namespace, rule, traces, regoResult)
 				continue
 			}
 
@@ -124,7 +124,7 @@ func (s *Scanner) convertResults(set rego.ResultSet, filepath string, namespace 
 				if regoResult.Message == "" {
 					regoResult.Message = fmt.Sprintf("Rego policy rule: %s.%s", namespace, rule)
 				}
-				results.AddRego(regoResult.Message, namespace, rule, regoResult)
+				results.AddRego(regoResult.Message, namespace, rule, traces, regoResult)
 			}
 		}
 	}

--- a/pkg/scan/result.go
+++ b/pkg/scan/result.go
@@ -29,6 +29,7 @@ type Result struct {
 	regoNamespace    string
 	regoRule         string
 	warning          bool
+	traces           []string
 }
 
 func (r Result) RegoNamespace() string {
@@ -98,6 +99,10 @@ func (r Result) Range() types.Range {
 	return r.metadata.Range()
 }
 
+func (r Result) Traces() []string {
+	return r.traces
+}
+
 type Results []Result
 
 type MetadataProvider interface {
@@ -142,12 +147,13 @@ func (r *Results) Add(description string, source MetadataProvider) {
 	*r = append(*r, result)
 }
 
-func (r *Results) AddRego(description string, namespace string, rule string, source MetadataProvider) {
+func (r *Results) AddRego(description string, namespace string, rule string, traces []string, source MetadataProvider) {
 	result := Result{
 		description:   description,
 		regoNamespace: namespace,
 		regoRule:      rule,
 		warning:       rule == "warn" || strings.HasPrefix(rule, "warn_"),
+		traces:        traces,
 	}
 	result.metadata = source.GetMetadata()
 	if result.metadata.IsExplicit() {

--- a/pkg/scanners/cloudformation/option.go
+++ b/pkg/scanners/cloudformation/option.go
@@ -64,6 +64,12 @@ func OptionWithTrace(w io.Writer) Option {
 	}
 }
 
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}
+
 func OptionWithParser(parser *parser.Parser) Option {
 	return func(s *Scanner) {
 		s.parser = parser

--- a/pkg/scanners/dockerfile/option.go
+++ b/pkg/scanners/dockerfile/option.go
@@ -40,6 +40,12 @@ func OptionWithTrace(w io.Writer) Option {
 	}
 }
 
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}
+
 func OptionWithParser(parser *parser.Parser) Option {
 	return func(s *Scanner) {
 		s.parser = parser

--- a/pkg/scanners/json/option.go
+++ b/pkg/scanners/json/option.go
@@ -37,3 +37,9 @@ func OptionWithTrace(w io.Writer) Option {
 		s.traceWriter = w
 	}
 }
+
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}

--- a/pkg/scanners/kubernetes/option.go
+++ b/pkg/scanners/kubernetes/option.go
@@ -51,3 +51,9 @@ func OptionWithParser(p *parser.Parser) Option {
 		s.parser = p
 	}
 }
+
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}

--- a/pkg/scanners/terraform/options.go
+++ b/pkg/scanners/terraform/options.go
@@ -194,3 +194,9 @@ func OptionWithRegoOnly(regoOnly bool) Option {
 		s.executorOpt = append(s.executorOpt, executor.OptionWithRegoOnly(regoOnly))
 	}
 }
+
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}

--- a/pkg/scanners/toml/option.go
+++ b/pkg/scanners/toml/option.go
@@ -37,3 +37,9 @@ func OptionWithTrace(w io.Writer) Option {
 		s.traceWriter = w
 	}
 }
+
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}

--- a/pkg/scanners/universal/options.go
+++ b/pkg/scanners/universal/options.go
@@ -44,6 +44,12 @@ func OptionWithTrace(w io.Writer) Option {
 	}
 }
 
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		OptionWithTrace(io.Discard)(s)
+	}
+}
+
 // OptionWithTerraformWorkspace specify Terraform workspace
 func OptionWithTerraformWorkspace(ws string) Option {
 	return func(s *Scanner) {

--- a/pkg/scanners/yaml/option.go
+++ b/pkg/scanners/yaml/option.go
@@ -37,3 +37,9 @@ func OptionWithTrace(w io.Writer) Option {
 		s.traceWriter = w
 	}
 }
+
+func OptionWithPerResultTracing() Option {
+	return func(s *Scanner) {
+		s.traceWriter = io.Discard
+	}
+}


### PR DESCRIPTION
Adds the `OptionWithPerResultTracing` rego scanner option. 

Mainly for compatibility with fanal/trivy.

This allows a consumer to gather rego traces on a per-result basis. When scans are run file-by-file, the scanner will attach traces to results found that are associated with the rule that detected the result, and the individual scan target (file). This means traces are easier to search for particular areas of interest.