### PR TITLE
fix(terraform): set module source in parsed ignores

### DIFF
--- a/pkg/scanners/terraform/parser/load_blocks.go
+++ b/pkg/scanners/terraform/parser/load_blocks.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func loadBlocksFromFile(file sourceFile) (hcl.Blocks, []terraform.Ignore, error) {
-	ignores := parseIgnores(file.file.Bytes, file.path)
+func loadBlocksFromFile(file sourceFile, moduleSource string) (hcl.Blocks, []terraform.Ignore, error) {
+	ignores := parseIgnores(file.file.Bytes, file.path, moduleSource)
 	contents, diagnostics := file.file.Body.Content(terraform.Schema)
 	if diagnostics != nil && diagnostics.HasErrors() {
 		return nil, nil, diagnostics
@@ -25,13 +25,13 @@ func loadBlocksFromFile(file sourceFile) (hcl.Blocks, []terraform.Ignore, error)
 	return contents.Blocks, ignores, nil
 }
 
-func parseIgnores(data []byte, path string) []terraform.Ignore {
+func parseIgnores(data []byte, path string, moduleSource string) []terraform.Ignore {
 	var ignores []terraform.Ignore
 	for i, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		lineIgnores := parseIgnoresFromLine(line)
 		for _, lineIgnore := range lineIgnores {
-			lineIgnore.Range = types.NewRange(path, i+1, i+1, "", nil)
+			lineIgnore.Range = types.NewRange(path, i+1, i+1, moduleSource, nil)
 			ignores = append(ignores, lineIgnore)
 		}
 	}

--- a/pkg/scanners/terraform/parser/parser.go
+++ b/pkg/scanners/terraform/parser/parser.go
@@ -289,7 +289,7 @@ func (p *Parser) readBlocks(files []sourceFile) (terraform.Blocks, terraform.Ign
 	var ignores terraform.Ignores
 	moduleCtx := tfcontext.NewContext(&hcl.EvalContext{}, nil)
 	for _, file := range files {
-		fileBlocks, fileIgnores, err := loadBlocksFromFile(file)
+		fileBlocks, fileIgnores, err := loadBlocksFromFile(file, p.moduleSource)
 		if err != nil {
 			if p.stopOnHCLError {
 				return nil, nil, err


### PR DESCRIPTION
Fixes [1670 issue in tfsec](https://github.com/aquasecurity/tfsec/issues/1670).

The comparison between a parsed ignore entry and a detected issue is done by filenames reported by `Range` objects in the issue and the ignore. The filenames contain the module path (as `sourcePrefix`) and relative path to the source file. Since the detected issue's `Range` had an empty string as module path, the comparison always failed for downloaded modules (as local modules had an empty string as module source).