### PR TITLE
test: add tests for aws lambda tf adapters

### DIFF
--- a/internal/adapters/terraform/aws/lambda/adapt_test.go
+++ b/internal/adapters/terraform/aws/lambda/adapt_test.go
@@ -4,27 +4,98 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/defsec/pkg/providers/aws/lambda"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/tftestutil"
+	"github.com/aquasecurity/defsec/internal/types"
 
 	"github.com/aquasecurity/defsec/test/testutil"
 )
 
 func Test_Adapt(t *testing.T) {
-	t.SkipNow()
 	tests := []struct {
 		name      string
 		terraform string
 		expected  lambda.Lambda
 	}{
 		{
-			name: "basic",
+			name: "reference arn",
 			terraform: `
-resource "" "example" {
-    
-}
+			resource "aws_lambda_function" "example" {
+				filename      = "lambda_function_payload.zip"
+				function_name = "lambda_function_name"
+				role          = aws_iam_role.iam_for_lambda.arn
+				runtime = "nodejs12.x"
+
+				tracing_config {
+				  mode = "Passthrough"
+				}
+			  }
+
+			  resource "aws_lambda_permission" "example" {
+				statement_id = "AllowExecutionFromSNS"
+				action = "lambda:InvokeFunction"
+				function_name = aws_lambda_function.example.function_name
+				principal = "sns.amazonaws.com"
+				source_arn = aws_sns_topic.default.arn
+			}
 `,
-			expected: lambda.Lambda{},
+			expected: lambda.Lambda{
+				Functions: []lambda.Function{
+					{
+						Metadata: types.NewTestMetadata(),
+						Tracing: lambda.Tracing{
+							Metadata: types.NewTestMetadata(),
+							Mode:     types.String("Passthrough", types.NewTestMetadata()),
+						},
+						Permissions: []lambda.Permission{
+							{
+								Metadata:  types.NewTestMetadata(),
+								Principal: types.String("sns.amazonaws.com", types.NewTestMetadata()),
+								SourceARN: types.String("default", types.NewTestMetadata()),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "defaults (with an orphan)",
+			terraform: `
+			resource "aws_lambda_function" "example" {
+				tracing_config {
+				}
+			  }
+
+			  resource "aws_lambda_permission" "example" {
+			  }
+`,
+			expected: lambda.Lambda{
+				Functions: []lambda.Function{
+					{
+						Metadata: types.NewTestMetadata(),
+						Tracing: lambda.Tracing{
+							Metadata: types.NewTestMetadata(),
+							Mode:     types.String("", types.NewTestMetadata()),
+						},
+					},
+					{
+						Metadata: types.NewTestMetadata(),
+						Tracing: lambda.Tracing{
+							Metadata: types.NewTestMetadata(),
+							Mode:     types.String("", types.NewTestMetadata()),
+						},
+						Permissions: []lambda.Permission{
+							{
+								Metadata:  types.NewTestMetadata(),
+								Principal: types.String("", types.NewTestMetadata()),
+								SourceARN: types.String("", types.NewTestMetadata()),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -35,4 +106,50 @@ resource "" "example" {
 			testutil.AssertDefsecEqual(t, test.expected, adapted)
 		})
 	}
+}
+
+func TestLines(t *testing.T) {
+	src := `
+	resource "aws_lambda_function" "example" {
+		filename      = "lambda_function_payload.zip"
+		function_name = "lambda_function_name"
+		role          = aws_iam_role.iam_for_lambda.arn
+		runtime = "nodejs12.x"
+
+		tracing_config {
+		  mode = "Passthrough"
+		}
+	  }
+
+	  resource "aws_lambda_permission" "example" {
+		statement_id = "AllowExecutionFromSNS"
+		action = "lambda:InvokeFunction"
+		function_name = aws_lambda_function.example.function_name
+		principal = "sns.amazonaws.com"
+		source_arn = "string arn"
+	}`
+
+	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
+	adapted := Adapt(modules)
+
+	require.Len(t, adapted.Functions, 1)
+	function := adapted.Functions[0]
+
+	assert.Equal(t, 2, function.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 11, function.GetMetadata().Range().GetEndLine())
+
+	assert.Equal(t, 8, function.Tracing.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 10, function.Tracing.GetMetadata().Range().GetEndLine())
+
+	assert.Equal(t, 9, function.Tracing.Mode.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 9, function.Tracing.Mode.GetMetadata().Range().GetEndLine())
+
+	assert.Equal(t, 13, function.Permissions[0].GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 19, function.Permissions[0].GetMetadata().Range().GetEndLine())
+
+	assert.Equal(t, 17, function.Permissions[0].Principal.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 17, function.Permissions[0].Principal.GetMetadata().Range().GetEndLine())
+
+	assert.Equal(t, 18, function.Permissions[0].SourceARN.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 18, function.Permissions[0].SourceARN.GetMetadata().Range().GetEndLine())
 }


### PR DESCRIPTION
test: add tests for aws lambda tf adapters
fix: assign permissions to functions they belong to
resolves #528 