### PR TITLE
fix(rule): GCP dnssec not applicable for private zones

### DIFF
--- a/internal/adapters/terraform/google/dns/adapt.go
+++ b/internal/adapters/terraform/google/dns/adapt.go
@@ -29,7 +29,8 @@ func adaptManagedZones(modules terraform.Modules) []dns.ManagedZone {
 func adaptManagedZone(resource *terraform.Block) dns.ManagedZone {
 
 	zone := dns.ManagedZone{
-		Metadata: resource.GetMetadata(),
+		Metadata:   resource.GetMetadata(),
+		Visibility: types.StringDefault("public", resource.GetMetadata()),
 		DNSSec: dns.DNSSec{
 			Metadata: resource.GetMetadata(),
 			Enabled:  types.BoolDefault(false, resource.GetMetadata()),
@@ -45,6 +46,10 @@ func adaptManagedZone(resource *terraform.Block) dns.ManagedZone {
 				},
 			},
 		},
+	}
+
+	if resource.HasChild("visibility") {
+		zone.Visibility = resource.GetAttribute("visibility").AsStringValueOrDefault("public", resource)
 	}
 
 	if resource.HasChild("dnssec_config") {

--- a/internal/adapters/terraform/google/dns/adapt_test.go
+++ b/internal/adapters/terraform/google/dns/adapt_test.go
@@ -42,7 +42,8 @@ func Test_Adapt(t *testing.T) {
 			expected: dns.DNS{
 				ManagedZones: []dns.ManagedZone{
 					{
-						Metadata: types.NewTestMetadata(),
+						Metadata:   types.NewTestMetadata(),
+						Visibility: types.String("public", types.NewTestMetadata()),
 						DNSSec: dns.DNSSec{
 							Enabled: types.Bool(true, types.NewTestMetadata()),
 							DefaultKeySpecs: dns.KeySpecs{

--- a/internal/rules/google/dns/enable_dnssec.go
+++ b/internal/rules/google/dns/enable_dnssec.go
@@ -29,7 +29,7 @@ var CheckEnableDnssec = rules.Register(
 	},
 	func(s *state.State) (results scan.Results) {
 		for _, zone := range s.Google.DNS.ManagedZones {
-			if zone.IsUnmanaged() {
+			if zone.IsUnmanaged() || zone.IsPrivate() {
 				continue
 			}
 			if zone.DNSSec.Enabled.IsFalse() {

--- a/internal/rules/google/dns/enable_dnssec_test.go
+++ b/internal/rules/google/dns/enable_dnssec_test.go
@@ -20,11 +20,12 @@ func TestCheckEnableDnssec(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "DNSSec disabled",
+			name: "DNSSec disabled and required when visibility explicitly public",
 			input: dns.DNS{
 				ManagedZones: []dns.ManagedZone{
 					{
-						Metadata: types.NewTestMetadata(),
+						Metadata:   types.NewTestMetadata(),
+						Visibility: types.String("public", types.NewTestMetadata()),
 						DNSSec: dns.DNSSec{
 							Metadata: types.NewTestMetadata(),
 							Enabled:  types.Bool(false, types.NewTestMetadata()),
@@ -39,7 +40,24 @@ func TestCheckEnableDnssec(t *testing.T) {
 			input: dns.DNS{
 				ManagedZones: []dns.ManagedZone{
 					{
-						Metadata: types.NewTestMetadata(),
+						Metadata:   types.NewTestMetadata(),
+						Visibility: types.String("public", types.NewTestMetadata()),
+						DNSSec: dns.DNSSec{
+							Metadata: types.NewTestMetadata(),
+							Enabled:  types.Bool(true, types.NewTestMetadata()),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "DNSSec not required when private",
+			input: dns.DNS{
+				ManagedZones: []dns.ManagedZone{
+					{
+						Metadata:   types.NewTestMetadata(),
+						Visibility: types.String("private", types.NewTestMetadata()),
 						DNSSec: dns.DNSSec{
 							Metadata: types.NewTestMetadata(),
 							Enabled:  types.Bool(true, types.NewTestMetadata()),

--- a/pkg/providers/google/dns/dns.go
+++ b/pkg/providers/google/dns/dns.go
@@ -10,7 +10,12 @@ type DNS struct {
 
 type ManagedZone struct {
 	types.Metadata
-	DNSSec DNSSec
+	DNSSec     DNSSec
+	Visibility types.StringValue
+}
+
+func (m ManagedZone) IsPrivate() bool {
+	return m.Visibility.EqualTo("private", types.IgnoreCase)
 }
 
 type DNSSec struct {


### PR DESCRIPTION
Resolves #538

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
