### PR TITLE
feat: Adds configurable loading of embedded libraries

### DIFF
--- a/internal/rules/embed.go
+++ b/internal/rules/embed.go
@@ -4,5 +4,8 @@ import (
 	"embed"
 )
 
-//go:embed */lib */policies
+//go:embed */policies
 var EmbeddedPolicyFileSystem embed.FS
+
+//go:embed */lib
+var EmbeddedLibraryFileSystem embed.FS

--- a/internal/rules/embed_test.go
+++ b/internal/rules/embed_test.go
@@ -7,8 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Embedding(t *testing.T) {
+func Test_EmbeddingPolicies(t *testing.T) {
 	entries, err := EmbeddedPolicyFileSystem.ReadDir(".")
+	require.NoError(t, err)
+	assert.Greater(t, len(entries), 0)
+}
+
+func Test_EmbeddingLibraries(t *testing.T) {
+	entries, err := EmbeddedLibraryFileSystem.ReadDir(".")
 	require.NoError(t, err)
 	assert.Greater(t, len(entries), 0)
 }

--- a/pkg/rego/embed.go
+++ b/pkg/rego/embed.go
@@ -19,6 +19,13 @@ func init() {
 		// we should panic as the policies were not embedded properly
 		panic(err)
 	}
+	loadedLibs, err := loadEmbeddedLibraries()
+	if err != nil {
+		panic(err)
+	}
+	for name, policy := range loadedLibs {
+		modules[name] = policy
+	}
 
 	ctx := context.TODO()
 
@@ -47,6 +54,10 @@ func init() {
 
 func loadEmbeddedPolicies() (map[string]*ast.Module, error) {
 	return recurseEmbeddedModules(rules.EmbeddedPolicyFileSystem, ".")
+}
+
+func loadEmbeddedLibraries() (map[string]*ast.Module, error) {
+	return recurseEmbeddedModules(rules.EmbeddedLibraryFileSystem, ".")
 }
 
 func recurseEmbeddedModules(fs embed.FS, dir string) (map[string]*ast.Module, error) {

--- a/pkg/scanners/cloudformation/scanner.go
+++ b/pkg/scanners/cloudformation/scanner.go
@@ -82,7 +82,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		return s.regoScanner, nil
 	}
 	regoScanner := rego.NewScanner(s.options...)
-	if err := regoScanner.LoadPolicies(true, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/dockerfile/scanner.go
+++ b/pkg/scanners/dockerfile/scanner.go
@@ -128,7 +128,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		return s.regoScanner, nil
 	}
 	regoScanner := rego.NewScanner(s.options...)
-	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/json/scanner.go
+++ b/pkg/scanners/json/scanner.go
@@ -123,7 +123,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		return s.regoScanner, nil
 	}
 	regoScanner := rego.NewScanner(s.options...)
-	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/terraform/options.go
+++ b/pkg/scanners/terraform/options.go
@@ -16,6 +16,7 @@ type ConfigurableTerraformScanner interface {
 	SetForceAllDirs(bool)
 	AddExecutorOptions(options ...executor.Option)
 	AddParserOptions(options ...options.ParserOption)
+	SetEmbeddedLibrariesEnabled(enabled bool)
 }
 
 func ScannerWithTFVarsPaths(paths ...string) options.ScannerOption {
@@ -191,6 +192,14 @@ func ScannerWithRegoOnly(regoOnly bool) options.ScannerOption {
 	return func(s options.ConfigurableScanner) {
 		if tf, ok := s.(ConfigurableTerraformScanner); ok {
 			tf.AddExecutorOptions(executor.OptionWithRegoOnly(regoOnly))
+		}
+	}
+}
+
+func ScannerWithEmbeddedLibraries(embedded bool) options.ScannerOption {
+	return func(s options.ConfigurableScanner) {
+		if tf, ok := s.(ConfigurableTerraformScanner); ok {
+			tf.SetEmbeddedLibrariesEnabled(embedded)
 		}
 	}
 }

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"path/filepath"
@@ -31,17 +32,22 @@ var _ options.ConfigurableScanner = (*Scanner)(nil)
 var _ ConfigurableTerraformScanner = (*Scanner)(nil)
 
 type Scanner struct {
-	options       []options.ScannerOption
-	parserOpt     []options.ParserOption
-	executorOpt   []executor.Option
-	dirs          map[string]struct{}
-	forceAllDirs  bool
-	policyDirs    []string
-	policyReaders []io.Reader
-	regoScanner   *rego.Scanner
-	execLock      sync.RWMutex
-	debug         debug.Logger
+	options                 []options.ScannerOption
+	parserOpt               []options.ParserOption
+	executorOpt             []executor.Option
+	dirs                    map[string]struct{}
+	forceAllDirs            bool
+	policyDirs              []string
+	policyReaders           []io.Reader
+	regoScanner             *rego.Scanner
+	execLock                sync.RWMutex
+	debug                   debug.Logger
+	enableEmbeddedLibraries bool
 	sync.Mutex
+}
+
+func (s *Scanner) SetEmbeddedLibrariesEnabled(enabled bool) {
+	s.enableEmbeddedLibraries = enabled
 }
 
 func (s *Scanner) Name() string {
@@ -119,7 +125,12 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		return s.regoScanner, nil
 	}
 	regoScanner := rego.NewScanner(s.options...)
-	if err := regoScanner.LoadPolicies(true, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if s.enableEmbeddedLibraries {
+		if err := regoScanner.LoadEmbeddedLibraries(); err != nil {
+			return nil, fmt.Errorf("failed to load embedded libraries: %w", err)
+		}
+	}
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/terraform/scanner_test.go
+++ b/pkg/scanners/terraform/scanner_test.go
@@ -443,6 +443,7 @@ deny[res] {
 		options.ScannerWithDebug(debugLog),
 		options.ScannerWithPolicyDirs("rules"),
 		ScannerWithRegoOnly(true),
+		ScannerWithEmbeddedLibraries(true),
 	)
 
 	results, err := scanner.ScanFS(context.TODO(), fs, "code")
@@ -513,6 +514,7 @@ deny[res] {
 		options.ScannerWithDebug(debugLog),
 		options.ScannerWithPolicyDirs("rules"),
 		ScannerWithRegoOnly(true),
+		ScannerWithEmbeddedLibraries(true),
 	)
 
 	results, err := scanner.ScanFS(context.TODO(), fs, "code")

--- a/pkg/scanners/toml/scanner.go
+++ b/pkg/scanners/toml/scanner.go
@@ -123,7 +123,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		return s.regoScanner, nil
 	}
 	regoScanner := rego.NewScanner(s.options...)
-	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/yaml/scanner.go
+++ b/pkg/scanners/yaml/scanner.go
@@ -121,7 +121,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 		return s.regoScanner, nil
 	}
 	regoScanner := rego.NewScanner(s.options...)
-	if err := regoScanner.LoadPolicies(len(s.policyDirs) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(len(s.policyDirs)+len(s.policyReaders) == 0, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner


### PR DESCRIPTION
Allows embedded rego libraries to be optionally loaded even when embedded policies are not.

(This will require a small tfsec update.)