### PR TITLE
feat: Add option to load policies from any given filesystem

### DIFF
--- a/pkg/rego/scanner.go
+++ b/pkg/rego/scanner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"strings"
 
 	"github.com/aquasecurity/defsec/internal/debug"
@@ -29,6 +30,11 @@ type Scanner struct {
 	traceWriter    io.Writer
 	tracePerResult bool
 	retriever      *MetadataRetriever
+	policyFS       fs.FS
+}
+
+func (s *Scanner) SetPolicyFilesystem(fs fs.FS) {
+	s.policyFS = fs
 }
 
 func (s *Scanner) SetPolicyReaders(_ []io.Reader) {

--- a/pkg/scanners/cloudformation/scanner.go
+++ b/pkg/scanners/cloudformation/scanner.go
@@ -58,6 +58,10 @@ func (s *Scanner) SetPolicyDirs(dirs ...string) {
 	s.policyDirs = dirs
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 func (s *Scanner) SetTraceWriter(_ io.Writer)        {}
 func (s *Scanner) SetPerResultTracingEnabled(_ bool) {}
 func (s *Scanner) SetDataDirs(_ ...string)           {}

--- a/pkg/scanners/dockerfile/scanner.go
+++ b/pkg/scanners/dockerfile/scanner.go
@@ -70,6 +70,10 @@ func (s *Scanner) SetPolicyNamespaces(_ ...string) {
 	// handled by rego later - nothing to do for now...
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/json/scanner.go
+++ b/pkg/scanners/json/scanner.go
@@ -61,6 +61,10 @@ func (s *Scanner) SetSkipRequiredCheck(skip bool) {
 	s.skipRequired = skip
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/kubernetes/scanner.go
+++ b/pkg/scanners/kubernetes/scanner.go
@@ -67,6 +67,10 @@ func (s *Scanner) SetPolicyNamespaces(_ ...string) {
 
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/options/scanner.go
+++ b/pkg/scanners/options/scanner.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"io"
+	"io/fs"
 )
 
 type ConfigurableScanner interface {
@@ -13,6 +14,7 @@ type ConfigurableScanner interface {
 	SetPolicyNamespaces(...string)
 	SetSkipRequiredCheck(bool)
 	SetPolicyReaders([]io.Reader)
+	SetPolicyFilesystem(fs.FS)
 }
 
 type ScannerOption func(s ConfigurableScanner)
@@ -65,5 +67,11 @@ func ScannerWithPolicyNamespaces(namespaces ...string) ScannerOption {
 func ScannerWithSkipRequiredCheck(skip bool) ScannerOption {
 	return func(s ConfigurableScanner) {
 		s.SetSkipRequiredCheck(skip)
+	}
+}
+
+func ScannerWithPolicyFilesystem(f fs.FS) ScannerOption {
+	return func(s ConfigurableScanner) {
+		s.SetPolicyFilesystem(f)
 	}
 }

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -94,6 +94,10 @@ func (s *Scanner) SetDataDirs(_ ...string) {
 func (s *Scanner) SetPolicyNamespaces(_ ...string) {
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 type Metrics struct {
 	Parser   parser.Metrics
 	Executor executor.Metrics

--- a/pkg/scanners/toml/scanner.go
+++ b/pkg/scanners/toml/scanner.go
@@ -65,6 +65,10 @@ func (s *Scanner) SetPolicyNamespaces(_ ...string) {
 
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/yaml/scanner.go
+++ b/pkg/scanners/yaml/scanner.go
@@ -61,6 +61,10 @@ func (s *Scanner) SetDataDirs(_ ...string) {
 func (s *Scanner) SetPolicyNamespaces(_ ...string) {
 }
 
+func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,


### PR DESCRIPTION
Useful when you are scanning a different filesystem to the one your custom rego policies live on