### PR TITLE
fix: Paramter ignores returning only the first matching block

### DIFF
--- a/pkg/terraform/ignore.go
+++ b/pkg/terraform/ignore.go
@@ -57,7 +57,7 @@ func (ignore Ignore) Covering(modules Modules, m types.Metadata, workspace strin
 			continue
 		}
 		if metaHierarchy.Range().GetStartLine() == ignore.Range.GetStartLine()+1 || metaHierarchy.Range().GetStartLine() == ignore.Range.GetStartLine() {
-			return ignore.MatchParams(modules)
+			return ignore.MatchParams(modules, metaHierarchy)
 		}
 		metaHierarchy = metaHierarchy.Parent()
 	}
@@ -65,11 +65,11 @@ func (ignore Ignore) Covering(modules Modules, m types.Metadata, workspace strin
 
 }
 
-func (ignore Ignore) MatchParams(modules Modules) bool {
+func (ignore Ignore) MatchParams(modules Modules, blockMetadata *types.Metadata) bool {
 	if len(ignore.Params) == 0 {
 		return true
 	}
-	block := modules.GetBlockByIgnoreRange(ignore.Range)
+	block := modules.GetBlockByIgnoreRange(blockMetadata)
 	if block == nil {
 		return true
 	}

--- a/pkg/terraform/modules.go
+++ b/pkg/terraform/modules.go
@@ -85,14 +85,15 @@ func (m Modules) GetResourceByIDs(id ...string) Blocks {
 	return blocks
 }
 
-func (m Modules) GetBlockByIgnoreRange(r types.Range) *Block {
+func (m Modules) GetBlockByIgnoreRange(blockMetadata *types.Metadata) *Block {
 	for _, module := range m {
 		for _, block := range module.GetBlocks() {
 			metadata := block.GetMetadata()
-			if br := metadata.Range(); br != nil && br.GetFilename() == r.GetFilename() && br.GetStartLine() == r.GetStartLine()+1 {
+			if blockMetadata.Reference().RefersTo(metadata.Reference()) {
 				return block
 			}
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
Ignores for a foreach using ignore range and returning first derived block, not the correct one

Resolves aquasecurity/tfsec#1693




Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
