### PR TITLE
fix: Issues with cache directory

### DIFF
--- a/pkg/scanners/terraform/parser/resolvers/remote.go
+++ b/pkg/scanners/terraform/parser/resolvers/remote.go
@@ -51,7 +51,7 @@ func (r *remoteResolver) Resolve(ctx context.Context, _ fs.FS, opt Options) (fil
 
 	baseCacheDir, err := locateCacheDir()
 	if err != nil {
-		return nil, "", "", false, fmt.Errorf("failed to locate cache directory: %w", err)
+		return nil, "", "", true, fmt.Errorf("failed to locate cache directory: %w", err)
 	}
 	cacheDir := filepath.Join(baseCacheDir, key)
 	if err := r.download(ctx, opt, cacheDir); err != nil {

--- a/pkg/scanners/terraform/parser/resolvers/remote.go
+++ b/pkg/scanners/terraform/parser/resolvers/remote.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -48,7 +49,11 @@ func (r *remoteResolver) Resolve(ctx context.Context, _ fs.FS, opt Options) (fil
 	key := cacheKey(opt.OriginalSource, opt.OriginalVersion, opt.RelativePath)
 	opt.Debug("Storing with cache key %s", key)
 
-	cacheDir := filepath.Join(locateCacheDir(), key)
+	baseCacheDir, err := locateCacheDir()
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("failed to locate cache directory: %w", err)
+	}
+	cacheDir := filepath.Join(baseCacheDir, key)
 	if err := r.download(ctx, opt, cacheDir); err != nil {
 		return nil, "", "", true, err
 	}


### PR DESCRIPTION
This fixes a few issues with the cache directory:

- The cache dir is no longer created until/unless it is needed (e.g. no longer created when `tfsec --help` is run etc.)
- Cache directory is now named `.aqua` to avoid confusion when `.tfsec` was being created in Trivy.
- Project directory is no longer tainted by the cache dir, causing issues in CI/docker etc.