### PR TITLE
feat: Add support for private/non-default terraform registries

### DIFF
--- a/pkg/scanners/terraform/parser/parser_test.go
+++ b/pkg/scanners/terraform/parser/parser_test.go
@@ -561,3 +561,41 @@ resource "something" "blah" {
 	assert.Equal(t, "c", values[2].Value())
 	assert.Equal(t, true, values[2].GetMetadata().IsResolvable())
 }
+
+func Test_DefaultRegistry(t *testing.T) {
+
+	fs := testutil.CreateFS(t, map[string]string{
+		"code/test.tf": `
+module "registry" {
+	source = "terraform-aws-modules/vpc/aws"
+}
+`,
+	})
+
+	parser := New(fs, "", OptionStopOnHCLError(true))
+	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
+		t.Fatal(err)
+	}
+	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, err)
+	require.Len(t, modules, 2)
+}
+
+func Test_SpecificRegistry(t *testing.T) {
+
+	fs := testutil.CreateFS(t, map[string]string{
+		"code/test.tf": `
+module "registry" {
+	source = "registry.terraform.io/terraform-aws-modules/vpc/aws"
+}
+`,
+	})
+
+	parser := New(fs, "", OptionStopOnHCLError(true))
+	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
+		t.Fatal(err)
+	}
+	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, err)
+	require.Len(t, modules, 2)
+}

--- a/pkg/scanners/terraform/parser/resolvers/cache.go
+++ b/pkg/scanners/terraform/parser/resolvers/cache.go
@@ -28,7 +28,7 @@ func locateCacheDir() (string, error) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", err
 	}
-	if isWritable(cacheDir) {
+	if !isWritable(cacheDir) {
 		return "", fmt.Errorf("cache directory is not writable")
 	}
 	return cacheDir, nil

--- a/pkg/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/scanners/terraform/parser/resolvers/registry.go
@@ -56,6 +56,11 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 
 		envVar := fmt.Sprintf("TF_TOKEN_%s", strings.ReplaceAll(hostname, ".", "_"))
 		token = os.Getenv(envVar)
+		if token != "" {
+			opt.Debug("Found a token for the registry at %s", hostname)
+		} else {
+			opt.Debug("No token was found for the registry at %s", hostname)
+		}
 	}
 
 	moduleName := strings.Join(parts, "/")

--- a/pkg/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/scanners/terraform/parser/resolvers/registry.go
@@ -35,6 +35,7 @@ type moduleVersions struct {
 
 const registryHostname = "registry.terraform.io"
 
+// nolint
 func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Options) (filesystem fs.FS, prefix string, downloadPath string, applies bool, err error) {
 
 	if !opt.AllowDownloads {


### PR DESCRIPTION
Terraform modules can now be retrieved from private registries.

The only authentication mechanism currently supported is environment variable. See the [Terraform docs](https://www.terraform.io/cli/config/config-file#environment-variable-credentials) for more info on using env vars for authentication.