### PR TITLE
fix: Fix scanning Helm charts with both embedded and custom policies

### DIFF
--- a/pkg/scanners/helm/scanner.go
+++ b/pkg/scanners/helm/scanner.go
@@ -145,7 +145,6 @@ func (s *Scanner) getScanResults(path string, ctx context.Context, target fs.FS)
 	}
 
 	regoScanner := rego.NewScanner(s.options...)
-	s.loadEmbedded = len(s.policyDirs)+len(s.policyReaders) == 0
 	policyFS := target
 	if s.policyFS != nil {
 		policyFS = s.policyFS

--- a/pkg/scanners/helm/test/scanner_test.go
+++ b/pkg/scanners/helm/test/scanner_test.go
@@ -151,6 +151,94 @@ func Test_helm_scanner_with_dir(t *testing.T) {
 	}
 }
 
+func Test_helm_scanner_with_custom_policies(t *testing.T) {
+	regoRule := `
+package user.kubernetes.ID001
+
+import data.lib.result
+
+__rego_metadata__ := {
+    "id": "ID001",
+	"avd_id": "AVD-USR-ID001",
+    "title": "Services not allowed",
+    "severity": "LOW",
+    "description": "Services are not allowed because of some reasons.",
+}
+
+__rego_input__ := {
+    "selector": [
+        {"type": "kubernetes"},
+    ],
+}
+
+deny[res] {
+    input.kind == "Service"
+    msg := sprintf("Found service '%s' but services are not allowed", [input.metadata.name])
+    res := result.new(msg, input)
+}
+`
+	tests := []struct {
+		testName    string
+		chartName   string
+		path        string
+		archiveName string
+	}{
+		{
+			testName:    "Parsing tarball 'mysql-8.8.26.tar'",
+			chartName:   "mysql",
+			path:        filepath.Join("testdata", "mysql-8.8.26.tar"),
+			archiveName: "mysql-8.8.26.tar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test: %s", test.testName)
+
+		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true),
+			options.ScannerWithPolicyDirs("rules"),
+			options.ScannerWithPolicyNamespaces("user"))
+
+		testTemp := t.TempDir()
+		testFileName := filepath.Join(testTemp, "chart", test.archiveName)
+		require.NoError(t, os.Mkdir(filepath.Dir(testFileName), 0o700))
+		require.NoError(t, copyArchive(test.path, testFileName))
+
+		policyDirName := filepath.Join(testTemp, "rules")
+		require.NoError(t, os.Mkdir(policyDirName, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(policyDirName, "rule.rego"), []byte(regoRule), 0o644))
+
+		testFs := os.DirFS(testTemp)
+
+		results, err := helmScanner.ScanFS(context.TODO(), testFs, "chart")
+		require.NoError(t, err)
+		require.NotNil(t, results)
+
+		failed := results.GetFailed()
+		assert.Equal(t, 14, len(failed))
+
+		visited := make(map[string]bool)
+		var errorCodes []string
+		for _, result := range failed {
+			id := result.Flatten().RuleID
+			if _, exists := visited[id]; !exists {
+				visited[id] = true
+				errorCodes = append(errorCodes, id)
+			}
+		}
+		assert.Len(t, errorCodes, 13)
+
+		sort.Strings(errorCodes)
+
+		assert.Equal(t, []string{
+			"AVD-KSV-0001", "AVD-KSV-0003",
+			"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
+			"AVD-KSV-0015", "AVD-KSV-0016", "AVD-KSV-0018",
+			"AVD-KSV-0020", "AVD-KSV-0021", "AVD-KSV-0030",
+			"AVD-KSV-0106", "AVD-USR-ID001",
+		}, errorCodes)
+	}
+}
+
 func copyArchive(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {


### PR DESCRIPTION
Do not force helm scanning to choose between either embedded policies, or user-provided policies.

Remove the implicit setting of `loadEmbedded` to false when policy directories are provided.

Unit test added to verify that both embedded and provided directories are used.