### PR TITLE
fix: Handle helm charts with templated names

### DIFF
--- a/pkg/scanners/helm/test/scanner_test.go
+++ b/pkg/scanners/helm/test/scanner_test.go
@@ -72,7 +72,7 @@ func Test_helm_scanner_with_archive(t *testing.T) {
 	}
 }
 
-func Test_malformed_helm_scanner_with_archive(t *testing.T) {
+func Test_helm_scanner_with_missing_name_can_recover(t *testing.T) {
 
 	tests := []struct {
 		testName    string
@@ -99,7 +99,7 @@ func Test_malformed_helm_scanner_with_archive(t *testing.T) {
 
 		testFs := os.DirFS(testTemp)
 		_, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
-		require.Error(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -168,4 +168,11 @@ func copyArchive(src, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func Test_helm_chart_with_templated_name(t *testing.T) {
+	helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true))
+	testFs := os.DirFS(filepath.Join("testdata", "templated-name"))
+	_, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
+	require.NoError(t, err)
 }

--- a/pkg/scanners/helm/test/testdata/templated-name/Chart.yaml
+++ b/pkg/scanners/helm/test/testdata/templated-name/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: {{COMPONENT_NAME}}
+version: {{COMPONENT_VERSION}}
+description: A Helm chart for Kubernetes
+keywords:
+  - kublr
+  - audit


### PR DESCRIPTION
Resolves #703 