### PR TITLE
feat: Add json and markdown format to --run-statistics

### DIFF
--- a/pkg/scanners/terraform/executor/statistics.go
+++ b/pkg/scanners/terraform/executor/statistics.go
@@ -48,7 +48,7 @@ func (statistics Statistics) PrintStatisticsTable(format string, w io.Writer) er
 			return err
 		}
 
-		fmt.Println(string(val))
+		_, _ = fmt.Fprintln(w, string(val))
 
 		return nil
 	}


### PR DESCRIPTION
Proposal: add formats json and markdown to statistics output

Why: https://github.com/aquasecurity/tfsec/issues/1790
