### PR TITLE
feat: add cisbenchmark checks for session 1.2 API Server

### DIFF
--- a/avd_docs/kubernetes/general/AVD-KCV-0001/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0001/docs.md
@@ -1,0 +1,13 @@
+
+Disable anonymous requests to the API server.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0002/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0002/docs.md
@@ -1,0 +1,13 @@
+
+Do not use token based authentication.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0003/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0003/docs.md
@@ -1,0 +1,13 @@
+
+This admission controller rejects all net-new usage of the Service field externalIPs.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0004/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0004/docs.md
@@ -1,0 +1,13 @@
+
+Use https for kubelet connections.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0005/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0005/docs.md
@@ -1,0 +1,13 @@
+
+Enable certificate based kubelet authentication.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0006/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0006/docs.md
@@ -1,0 +1,13 @@
+
+Verify kubelet's certificate before establishing connection.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0007/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0007/docs.md
@@ -1,0 +1,13 @@
+
+Do not always authorize all requests.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0008/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0008/docs.md
@@ -1,0 +1,13 @@
+
+Restrict kubelet nodes to reading only objects associated with them.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0009/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0009/docs.md
@@ -1,0 +1,13 @@
+
+Turn on Role Based Access Control.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0010/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0010/docs.md
@@ -1,0 +1,13 @@
+
+Limit the rate at which the API server accepts requests.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0011/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0011/docs.md
@@ -1,0 +1,13 @@
+
+Do not allow all requests.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0012/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0012/docs.md
@@ -1,0 +1,13 @@
+
+Always pull images.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0013/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0013/docs.md
@@ -1,0 +1,13 @@
+
+The SecurityContextDeny admission controller can be used to deny pods which make use of some SecurityContext fields which could allow for privilege escalation in the cluster. This should be used where PodSecurityPolicy is not in place within the cluster.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0014/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0014/docs.md
@@ -1,0 +1,13 @@
+
+Automate service accounts management.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0015/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0015/docs.md
@@ -1,0 +1,13 @@
+
+Reject creating objects in a namespace that is undergoing termination.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0016/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0016/docs.md
@@ -1,0 +1,13 @@
+
+Limit the Node and Pod objects that a kubelet could modify.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0017/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0017/docs.md
@@ -1,0 +1,13 @@
+
+Do not disable the secure port.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0018/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0018/docs.md
@@ -1,0 +1,13 @@
+
+Disable profiling, if not needed.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0019/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0019/docs.md
@@ -1,0 +1,13 @@
+
+Enable auditing on the Kubernetes API Server and set the desired audit log path.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0020/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0020/docs.md
@@ -1,0 +1,13 @@
+
+Retain the logs for at least 30 days or as appropriate.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0021/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0021/docs.md
@@ -1,0 +1,13 @@
+
+Retain 10 or an appropriate number of old log files.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0022/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0022/docs.md
@@ -1,0 +1,13 @@
+
+Rotate log files on reaching 100 MB or as appropriate.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0024/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0024/docs.md
@@ -1,0 +1,13 @@
+
+Validate service account before validating token.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0025/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0025/docs.md
@@ -1,0 +1,13 @@
+
+Explicitly set a service account public key file for service accounts on the apiserver.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0026/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0026/docs.md
@@ -1,0 +1,13 @@
+
+etcd should be configured to make use of TLS encryption for client connections.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0027/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0027/docs.md
@@ -1,0 +1,13 @@
+
+Setup TLS connection on the API server.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0028/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0028/docs.md
@@ -1,0 +1,13 @@
+
+Setup TLS connection on the API server.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0029/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0029/docs.md
@@ -1,0 +1,13 @@
+
+etcd should be configured to make use of TLS encryption for client connections.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/avd_docs/kubernetes/general/AVD-KCV-0030/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KCV-0030/docs.md
@@ -1,0 +1,13 @@
+
+Encrypt etcd key-value store.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://www.cisecurity.org/benchmark/kubernetes
+
+

--- a/internal/rules/kubernetes/lib/kubernetes.rego
+++ b/internal/rules/kubernetes/lib/kubernetes.rego
@@ -166,3 +166,11 @@ host_aliases[host_alias] {
 	pods[pod]
 	host_alias = pod.spec
 }
+
+is_apiserver(container) {
+	regex.match("kube-apiserver", container.command[0])
+}
+
+command_has_flag(command, flag) {
+	regex.match(flag, command[_])
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_admit_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_admit_plugin.rego
@@ -1,0 +1,36 @@
+package builtin.kubernetes.KCV0011
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0011",
+	"avd_id": "AVD-KCV-0011",
+	"title": "Ensure that the admission control plugin AlwaysAdmit is not set",
+	"short_code": "ensure-admission-control-plugin-always-admit-is-not-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Do not allow all requests.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and either remove the --enable-admission- plugins parameter, or set it to a value that does not include AlwaysAdmit.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	regex.match("AlwaysAdmit", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin AlwaysAdmit is not set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_admit_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_admit_plugin_test.rego
@@ -1,0 +1,87 @@
+package builtin.kubernetes.KCV0011
+
+test_always_admin_plugin_is_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=AlwaysAdmit"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin AlwaysAdmit is not set"
+}
+
+test_always_admit_plugin_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_always_admit_plugin_is_not_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_always_admit_plugin_is_enabled_with_others {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,AlwaysAdmit,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin AlwaysAdmit is not set"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_pull_images_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_pull_images_plugin.rego
@@ -1,0 +1,41 @@
+package builtin.kubernetes.KCV0012
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KSV0012",
+	"avd_id": "AVD-KCV-0012",
+	"title": "Ensure that the admission control plugin AlwaysPullImages is set",
+	"short_code": "ensure-admission-control-plugin-always-pull-images-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Always pull images.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --enable-admission-plugins parameter to include AlwaysPullImages.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--enable-admission-plugins")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	not regex.match("AlwaysPullImages", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin AlwaysPullImages is set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_pull_images_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/always_pull_images_plugin_test.rego
@@ -1,0 +1,87 @@
+package builtin.kubernetes.KCV0012
+
+test_always_pull_images_plugin_is_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=AlwaysPullImages"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_always_pull_images_plugin_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin AlwaysPullImages is set"
+}
+
+test_always_pull_images_plugin_is_not_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin AlwaysPullImages is set"
+}
+
+test_always_pull_images_plugin_is_enabled_with_others {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,AlwaysPullImages,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/anonymous_auth.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/anonymous_auth.rego
@@ -1,0 +1,36 @@
+package builtin.kubernetes.KCV0001
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0001",
+	"avd_id": "AVD-KCV-0001",
+	"title": "Ensure that the --anonymous-auth argument is set to false",
+	"short_code": "ensure-anonymous-auth-argument-is-false",
+	"version": "v1.0.0",
+	"severity": "MEDIUM",
+	"type": "Kubernetes Security Check",
+	"description": "Disable anonymous requests to the API server.",
+	"recommended_actions": "Set '--anonymous-auth' to 'false'.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	flag := container.command[i]
+	not kubernetes.command_has_flag(container.command, "--anonymous-auth=false")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --anonymous-auth argument is set to false"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/anonymous_auth_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/anonymous_auth_test.rego
@@ -1,0 +1,66 @@
+package builtin.kubernetes.KCV0001
+
+test_anonymous_requests_default_value {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --anonymous-auth argument is set to false"
+}
+
+test_anonymous_requests_true {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --anonymous-auth argument is set to false"
+}
+
+test_anonymous_requests_false {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxage.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxage.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0020
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0020",
+	"avd_id": "AVD-KCV-0020",
+	"title": "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate",
+	"short_code": "ensure-audit-log-maxage-argument-is-set-to-30-or-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Retain the logs for at least 30 days or as appropriate.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--audit-log-maxage")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxage_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxage_test.rego
@@ -1,0 +1,65 @@
+package builtin.kubernetes.KCV0020
+
+test_audit_log_maxage_is_set_30 {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-maxage=30"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_maxage_is_set_10 {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-maxage=30", "--secure-port=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_maxage_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--profiling=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxbackup.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxbackup.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0021
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0021",
+	"avd_id": "AVD-KCV-0021",
+	"title": "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate",
+	"short_code": "ensure-audit-log-maxbackup-argument-is-set-to-10-or-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Retain 10 or an appropriate number of old log files.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate value.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--audit-log-maxbackup")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxbackup_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxbackup_test.rego
@@ -1,0 +1,65 @@
+package builtin.kubernetes.KCV0021
+
+test_audit_log_maxbackup_is_set_30 {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-maxbackup=30"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_maxbackup_is_set_10 {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-maxbackup=30", "--secure-port=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_maxbackup_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--profiling=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxsize.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxsize.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0022
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0022",
+	"avd_id": "AVD-KCV-0022",
+	"title": "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate",
+	"short_code": "ensure-audit-log-maxsize-argument-is-set-to-100-or-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Rotate log files on reaching 100 MB or as appropriate.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --audit-log-maxsize parameter to an appropriate size in MB",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--audit-log-maxsize")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxsize_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_maxsize_test.rego
@@ -1,0 +1,65 @@
+package builtin.kubernetes.KCV0022
+
+test_audit_log_maxsize_is_set_100 {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-maxsize=100"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_maxsize_is_set_10 {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-maxsize=10", "--secure-port=10"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_maxsize_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--profiling=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_path.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_path.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0019
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0019",
+	"avd_id": "AVD-KCV-0019",
+	"title": "Ensure that the --audit-log-path argument is set",
+	"short_code": "ensure-audit-log-path-argument-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Enable auditing on the Kubernetes API Server and set the desired audit log path.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --audit-log-path parameter.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--audit-log-path")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --audit-log-path argument is set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_path_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/audit_log_path_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0019
+
+test_audit_log_path_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--audit-log-path=<path>", "--secure-port=0"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_audit_log_path_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--profiling=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --audit-log-path argument is set"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode.rego
@@ -1,0 +1,36 @@
+package builtin.kubernetes.KCV0007
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0007",
+	"avd_id": "AVD-KCV-0007",
+	"title": "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
+	"short_code": "ensure-authorization-mode-argument-is-not-set-to-alwaysallow",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Do not always authorize all requests.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --authorization-mode parameter to values other than AlwaysAllow. ",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.command[i], -1)
+	regex.match("AlwaysAllow", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --authorization-mode argument is not set to AlwaysAllow"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_node.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_node.rego
@@ -1,0 +1,41 @@
+package builtin.kubernetes.KCV0008
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0008",
+	"avd_id": "AVD-KCV-0008",
+	"title": "Ensure that the --authorization-mode argument includes Node",
+	"short_code": "ensure-authorization-mode-argument-includes-node",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Restrict kubelet nodes to reading only objects associated with them.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --authorization-mode parameter to a value that includes Node.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--authorization-mode")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	some i
+	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.command[i], -1)
+	not regex.match("Node", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --authorization-mode argument includes Node"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_node_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_node_test.rego
@@ -1,0 +1,109 @@
+package builtin.kubernetes.KCV0008
+
+test_authorization_mode_is_set_node {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_authorization_mode_includes_node {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=RBAC,Node", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_authorization_mode_default_value {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument includes Node"
+}
+
+test_authorization_mode_is_set_rbac {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument includes Node"
+}
+
+test_authorization_mode_with_multiple_values {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=ABAC,Webhook,AlwaysAllow", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument includes Node"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_rbac.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_rbac.rego
@@ -1,0 +1,41 @@
+package builtin.kubernetes.KCV0009
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0009",
+	"avd_id": "AVD-KCV-0009",
+	"title": "Ensure that the --authorization-mode argument includes RBAC",
+	"short_code": "ensure-authorization-mode-argument-includes-rbac",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Turn on Role Based Access Control.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --authorization-mode parameter to a value that includes RBAC.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--authorization-mode")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	some i
+	output := regex.find_all_string_submatch_n(`--authorization-mode=([^\s]+)`, container.command[i], -1)
+	not regex.match("RBAC", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --authorization-mode argument includes RBAC"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_rbac_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_includes_rbac_test.rego
@@ -1,0 +1,109 @@
+package builtin.kubernetes.KCV0009
+
+test_authorization_mode_is_set_rbac {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_authorization_mode_includes_rbac {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_authorization_mode_default_value {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument includes RBAC"
+}
+
+test_authorization_mode_is_set_node {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument includes RBAC"
+}
+
+test_authorization_mode_with_multiple_values {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=ABAC,Webhook,AlwaysAllow", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument includes RBAC"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/authorization_mode_test.rego
@@ -1,0 +1,66 @@
+package builtin.kubernetes.KCV0007
+
+test_authorization_mode_is_set_alwaysallow {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument is not set to AlwaysAllow"
+}
+
+test_authorization_mode_is_set_rbac {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_authorization_mode_with_multiple_values {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=ABAC,Webhook,AlwaysAllow", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --authorization-mode argument is not set to AlwaysAllow"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0028
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0028",
+	"avd_id": "AVD-KCV-0028",
+	"title": "Ensure that the --client-ca-file argument is set as appropriate",
+	"short_code": "ensure-client-ca-file-argument-is-set-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Setup TLS connection on the API server.",
+	"recommended_actions": "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the client certificate authority file.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	kubernetes.command_has_flag(container.command, "--client-ca-file")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --client-ca-file argument is set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0028
+
+test_client_ca_file_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--client-ca-file=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --client-ca-file argument is set as appropriate"
+}
+
+test_client_ca_file_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/deny_service_external_ips_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/deny_service_external_ips_plugin.rego
@@ -1,0 +1,35 @@
+package builtin.kubernetes.KCV0003
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0003",
+	"avd_id": "AVD-KCV-0003",
+	"title": "Ensure that the --DenyServiceExternalIPs is not set",
+	"short_code": "Ensure-deny-service-external-ips-is-not-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "This admission controller rejects all net-new usage of the Service field externalIPs.",
+	"recommended_actions": "Edit the API server pod specification file $apiserverconf on the control plane node and remove the `DenyServiceExternalIPs` from enabled admission plugins.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	regex.match("DenyServiceExternalIPs", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --DenyServiceExternalIPs is not set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/deny_service_external_ips_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/deny_service_external_ips_plugin_test.rego
@@ -1,0 +1,87 @@
+package builtin.kubernetes.KCV0003
+
+test_deny_service_external_ips_is_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=DenyServiceExternalIPs"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --DenyServiceExternalIPs is not set"
+}
+
+test_enable_admission_plugins_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_deny_service_external_ips_is_not_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_deny_service_external_ips_is_enabled_with_others {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,DenyServiceExternalIPs,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --DenyServiceExternalIPs is not set"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/encryption_provider_config.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/encryption_provider_config.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0030
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0030",
+	"avd_id": "AVD-KCV-0030",
+	"title": "Ensure that the --encryption-provider-config argument is set as appropriate",
+	"short_code": "Ensure that the --encryption-provider-config argument is set as appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Encrypt etcd key-value store.",
+	"recommended_actions": "Follow the Kubernetes documentation and configure a EncryptionConfig file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --encryption-provider-config parameter to the path of that file",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	kubernetes.command_has_flag(container.command, "--encryption-provider-config")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --encryption-provider-config argument is set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/encryption_provider_config_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/encryption_provider_config_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0030
+
+test_encryption_provider_config_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--encryption-provider-config=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --encryption-provider-config argument is set as appropriate"
+}
+
+test_encryption_provider_config_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0029
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0029",
+	"avd_id": "AVD-KCV-0029",
+	"title": "Ensure that the --etcd-cafile argument is set as appropriate",
+	"short_code": "ensure-etcd-cafile-argument-is-set-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "etcd should be configured to make use of TLS encryption for client connections.",
+	"recommended_actions": "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate authority file parameter.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	kubernetes.command_has_flag(container.command, "--etcd-cafile")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --etcd-cafile argument is set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0029
+
+test_etcd_cafile_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--etcd-cafile=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --etcd-cafile argument is set as appropriate"
+}
+
+test_etcd_cafile_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_certfile_and_keyfile.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_certfile_and_keyfile.rego
@@ -1,0 +1,40 @@
+package builtin.kubernetes.KCV0026
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0026",
+	"avd_id": "AVD-KCV-0026",
+	"title": "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate",
+	"short_code": "ensure-etcd-certfile-and-etcd-keyfile-arguments-are-set-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "etcd should be configured to make use of TLS encryption for client connections.",
+	"recommended_actions": "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate and key file parameters.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--etcd-certfile")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--etcd-keyfile")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_certfile_and_keyfile_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_certfile_and_keyfile_test.rego
@@ -1,0 +1,88 @@
+package builtin.kubernetes.KCV0026
+
+test_only_etcd_certfile_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--etcd-certfile=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
+}
+
+test_only_etcd_keyfile_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--etcd-keyfile=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
+}
+
+test_etcd_certfile_and_keyfile_are_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--etcd-certfile=<file>", "--etcd-keyfile=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_etcd_certfile_and_keyfile_are_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/event_rate_limit_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/event_rate_limit_plugin.rego
@@ -1,0 +1,41 @@
+package builtin.kubernetes.KCV0010
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0010",
+	"avd_id": "AVD-KCV-0010",
+	"title": "Ensure that the admission control plugin EventRateLimit is set",
+	"short_code": "ensure-admission-control-plugin-event-rate-limit-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Limit the rate at which the API server accepts requests.",
+	"recommended_actions": "Follow the Kubernetes documentation and set the desired limits in a configuration file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--enable-admission-plugins")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	not regex.match("EventRateLimit", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin EventRateLimit is set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/event_rate_limit_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/event_rate_limit_plugin_test.rego
@@ -1,0 +1,87 @@
+package builtin.kubernetes.KCV0010
+
+test_event_rate_limit_plugin_is_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=EventRateLimit"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_event_rate_limit_plugin_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin EventRateLimit is set"
+}
+
+test_event_rate_limit_plugin_is_not_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin EventRateLimit is set"
+}
+
+test_event_rate_limit_plugin_is_enabled_with_others {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,EventRateLimit,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_certificate_authority.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_certificate_authority.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0006
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0006",
+	"avd_id": "AVD-KCV-0006",
+	"title": "Ensure that the --kubelet-certificate-authority argument is set as appropriate",
+	"short_code": "ensure-kubelet-certificate-authority-argument-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Verify kubelet's certificate before establishing connection.",
+	"recommended_actions": "Follow the Kubernetes documentation and setup the TLS connection between the apiserver and kubelets. ",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--kubelet-certificate-authority")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --kubelet-certificate-authority argument is set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_certificate_authority_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_certificate_authority_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0006
+
+test_kubelet_certificate_authority_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--kubelet-certificate-authority=<ca-string>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_kubelet_certificate_authority_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --kubelet-certificate-authority argument is set as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_client_certificate_and_key.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_client_certificate_and_key.rego
@@ -1,0 +1,40 @@
+package builtin.kubernetes.KCV0005
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0005",
+	"avd_id": "AVD-KCV-0005",
+	"title": "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate",
+	"short_code": "ensure-kubelet-client-certificate-and-kubelet-client-key-are-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Enable certificate based kubelet authentication.",
+	"recommended_actions": "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and kubelets.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--kubelet-client-certificate")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--kubelet-client-key")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_client_certificate_and_key_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_client_certificate_and_key_test.rego
@@ -1,0 +1,88 @@
+package builtin.kubernetes.KCV0005
+
+test_only_kubelet_client_certificate_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--kubelet-client-certificate=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate"
+}
+
+test_only_kubelet_client_key_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--kubelet-client-key=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate"
+}
+
+test_kubelet_client_key_and_certificate_are_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--kubelet-client-certificate=<file>", "--kubelet-client-key=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_kubelet_client_key_and_certificate_are_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_https.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_https.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0004
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0004",
+	"avd_id": "AVD-KCV-0004",
+	"title": "Ensure that the --kubelet-https argument is set to true",
+	"short_code": "ensure-kubelet-https-argument-is-set-to-true",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Use https for kubelet connections.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and remove the --kubelet-https parameter.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	kubernetes.command_has_flag(container.command, "--kubelet-https=false")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --kubelet-https argument is set to true"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_https_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/kubelet_https_test.rego
@@ -1,0 +1,65 @@
+package builtin.kubernetes.KCV0004
+
+test_kubelet_https_is_false {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--kubelet-https=false", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --kubelet-https argument is set to true"
+}
+
+test_kubelet_https_is_true {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--kubelet-https=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_kubelet_https_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/namespace_lifecycle_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/namespace_lifecycle_plugin.rego
@@ -1,0 +1,36 @@
+package builtin.kubernetes.KCV0015
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0015",
+	"avd_id": "AVD-KCV-0015",
+	"title": "Ensure that the admission control plugin NamespaceLifecycle is set",
+	"short_code": "ensure-admission-control-plugin-namespace-lifecycle-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Reject creating objects in a namespace that is undergoing termination.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --disable-admission-plugins parameter to ensure it does not include NamespaceLifecycle.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	output := regex.find_all_string_submatch_n(`--disable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	regex.match("NamespaceLifecycle", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin NamespaceLifecycle is set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/namespace_lifecycle_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/namespace_lifecycle_plugin_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0015
+
+test_namespace_lifecycle_plugin_is_disabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--disable-admission-plugins=AlwaysAdmit,NamespaceLifecycle"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin NamespaceLifecycle is set"
+}
+
+test_namespace_lifecycle_plugin_is_not_disabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--disable-admission-plugins=AlwaysAdmit"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/node_restriction_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/node_restriction_plugin.rego
@@ -1,0 +1,41 @@
+package builtin.kubernetes.KCV0016
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0016",
+	"avd_id": "AVD-KCV-0016",
+	"title": "Ensure that the admission control plugin NodeRestriction is set",
+	"short_code": "ensure-admission-control-plugin-node-restriction-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Limit the Node and Pod objects that a kubelet could modify.",
+	"recommended_actions": "Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to a value that includes NodeRestriction.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--enable-admission-plugins")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	not regex.match("NodeRestriction", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin NodeRestriction is set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/node_restriction_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/node_restriction_plugin_test.rego
@@ -1,0 +1,87 @@
+package builtin.kubernetes.KCV0016
+
+test_node_restriction_plugin_is_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NodeRestriction"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_enable_admission_plugins_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=Node,RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin NodeRestriction is set"
+}
+
+test_node_restriction__plugin_is_not_enabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin NodeRestriction is set"
+}
+
+test_node_restriction_plugin_is_enabled_with_others {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=NamespaceLifecycle,NodeRestriction,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/profiling.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/profiling.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0018
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0018",
+	"avd_id": "AVD-KCV-0018",
+	"title": "Ensure that the --profiling argument is set to false",
+	"short_code": "ensure-profiling-argument-is-set-to-false",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Disable profiling, if not needed.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the below parameter.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--profiling=false")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --profiling argument is set to false"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/profiling_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/profiling_test.rego
@@ -1,0 +1,66 @@
+package builtin.kubernetes.KCV0018
+
+test_profiling_is_set_to_false {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--profiling=false", "--secure-port=0"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_profiling_is_set_to_true {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--profiling=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --profiling argument is set to false"
+}
+
+test_profiling_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --profiling argument is set to false"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/secure_port.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/secure_port.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0017
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0017",
+	"avd_id": "AVD-KCV-0017",
+	"title": "Ensure that the --secure-port argument is not set to 0",
+	"short_code": "ensure-secure-port-argument-is-not-set-to-0",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Do not disable the secure port.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and either remove the --secure-port parameter or set it to a different (non-zero) desired port.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	kubernetes.command_has_flag(container.command, "--secure-port=0")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --secure-port argument is not set to 0"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/secure_port_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/secure_port_test.rego
@@ -1,0 +1,65 @@
+package builtin.kubernetes.KCV0017
+
+test_secure_port_is_set_to_zero {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--secure-port=0"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --secure-port argument is not set to 0"
+}
+
+test_secure_port_is_not_set_to_zero {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--secure-port=2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_secure_port_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/security_context_deny_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/security_context_deny_plugin.rego
@@ -1,0 +1,37 @@
+package builtin.kubernetes.KCV0013
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0013",
+	"avd_id": "AVD-KCV-0013",
+	"title": "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used",
+	"short_code": "ensure-admission-control-plugin-security-context-deny-is-set-if-pod-security-policy-is-not-used",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "The SecurityContextDeny admission controller can be used to deny pods which make use of some SecurityContext fields which could allow for privilege escalation in the cluster. This should be used where PodSecurityPolicy is not in place within the cluster.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --enable-admission-plugins parameter to include SecurityContextDeny, unless PodSecurityPolicy is already in place.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	output := regex.find_all_string_submatch_n(`--enable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	not regex.match("PodSecurityPolicy", output[0][1])
+	not regex.match("SecurityContextDeny", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/security_context_deny_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/security_context_deny_plugin_test.rego
@@ -1,0 +1,86 @@
+package builtin.kubernetes.KCV0013
+
+test_pod_security_policy_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=AlwaysPullImages,PodSecurityPolicy"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_pod_security_policy_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=AlwaysPullImages"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used"
+}
+
+test_pod_security_policy_is_not_set_and_seurity_context_deny_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=AlwaysPullImages,SecurityContextDeny"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_both_pod_security_policy_and_seurity_context_deny_are_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--enable-admission-plugins=AlwaysPullImages,PodSecrutiyPolicy,SecurityContextDeny"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_key_file.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_key_file.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0025
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0025",
+	"avd_id": "AVD-KCV-0025",
+	"title": "Ensure that the --service-account-key-file argument is set as appropriate",
+	"short_code": "ensure-service-account-key-file-argument-is-set-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Explicitly set a service account public key file for service accounts on the apiserver.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the --service-account-key-file parameter to the public key file for service accounts.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--service-account-key-file")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --service-account-key-file argument is set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_key_file_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_key_file_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0025
+
+test_service_account_key_file_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--service-account-key-file=<file>", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_service_account_key_file_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--service-account-lookup=true"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --service-account-key-file argument is set as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_lookup.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_lookup.rego
@@ -1,0 +1,34 @@
+package builtin.kubernetes.KCV0024
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0024",
+	"avd_id": "AVD-KCV-0024",
+	"title": "Ensure that the --service-account-lookup argument is set to true",
+	"short_code": "ensure-service-account-lookup-argument-is-set-to-true",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Validate service account before validating token.",
+	"recommended_actions": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the below parameter.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	kubernetes.command_has_flag(container.command, "--service-account-lookup=false")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --service-account-lookup argument is set to true"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_lookup_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_lookup_test.rego
@@ -1,0 +1,65 @@
+package builtin.kubernetes.KCV0024
+
+test_service_account_lookup_is_false {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--service-account-lookup=false", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --service-account-lookup argument is set to true"
+}
+
+test_service_account_lookup_is_true {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=AlwaysAllow", "--service-account-lookup=true", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_service_account_lookup_is_not_configured {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--authorization-mode=RBAC", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_plugin.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_plugin.rego
@@ -1,0 +1,36 @@
+package builtin.kubernetes.KCV0014
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0014",
+	"avd_id": "AVD-KCV-0014",
+	"title": "Ensure that the admission control plugin ServiceAccount is set",
+	"short_code": "ensure-admission-control-plugin-service-account-is-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Automate service accounts management.",
+	"recommended_actions": "Follow the documentation and create ServiceAccount objects as per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and ensure that the --disable-admission-plugins parameter is set to a value that does not include ServiceAccount.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	output := regex.find_all_string_submatch_n(`--disable-admission-plugins=([^\s]+)`, container.command[i], -1)
+	regex.match("ServiceAccount", output[0][1])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the admission control plugin ServiceAccount is set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_plugin_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/service_account_plugin_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0014
+
+test_service_account_plugin_is_disabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--disable-admission-plugins=AlwaysAdmit,ServiceAccount"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the admission control plugin ServiceAccount is set"
+}
+
+test_service_account_plugin_is_not_disabled {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--disable-admission-plugins=AlwaysAdmit"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file.rego
@@ -1,0 +1,40 @@
+package builtin.kubernetes.KCV0027
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0027",
+	"avd_id": "AVD-KCV-0027",
+	"title": "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate",
+	"short_code": "ensure-tls-cert-file-and-tls-private-key-file-arguments-are-set-as-appropriate",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Setup TLS connection on the API server.",
+	"recommended_actions": "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the TLS certificate and private key file parameters.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--tls-cert-file")
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	not kubernetes.command_has_flag(container.command, "--tls-private-key-file")
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/tls_cert_file_and_private_key_file_test.rego
@@ -1,0 +1,88 @@
+package builtin.kubernetes.KCV0027
+
+test_only_tls_cert_file_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--tls-cert-file=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate"
+}
+
+test_only_tls_private_key_file_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--tls-private-key-file=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate"
+}
+
+test_tls_cert_file_and_private_key_file_are_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--tls-cert-file=<file>", "--tls-private-key-file=<file>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_tls_cert_file_and_private_key_file_are_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate"
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/token_auth_file.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/token_auth_file.rego
@@ -1,0 +1,35 @@
+package builtin.kubernetes.KCV0002
+
+import data.lib.kubernetes
+import data.lib.result
+
+__rego_metadata__ := {
+	"id": "KCV0002",
+	"avd_id": "AVD-KCV-0002",
+	"title": "Ensure that the --token-auth-file parameter is not set",
+	"short_code": "ensure-token-auth-file-parameter-is-not-set",
+	"version": "v1.0.0",
+	"severity": "LOW",
+	"type": "Kubernetes Security Check",
+	"description": "Do not use token based authentication.",
+	"recommended_actions": "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --token-auth-file=<filename> parameter.",
+	"url": "https://www.cisecurity.org/benchmark/kubernetes",
+}
+
+__rego_input__ := {
+	"combine": false,
+	"selector": [{"type": "kubernetes"}],
+}
+
+check_flag[container] {
+	container := kubernetes.containers[_]
+	kubernetes.is_apiserver(container)
+	some i
+	regex.match("--token-auth-file", container.command[i])
+}
+
+deny[res] {
+	output := check_flag[_]
+	msg := "Ensure that the --token-auth-file parameter is not set"
+	res := result.new(msg, output)
+}

--- a/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/token_auth_file_test.rego
+++ b/internal/rules/kubernetes/policies/cisbenchmarks/apiserver/token_auth_file_test.rego
@@ -1,0 +1,44 @@
+package builtin.kubernetes.KCV0002
+
+test_token_auth_file_is_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--token-auth-file=<filename>"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Ensure that the --token-auth-file parameter is not set"
+}
+
+test_token_auth_file_is_not_set {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "apiserver",
+			"labels": {
+				"component": "kube-apiserver",
+				"tier": "control-plane",
+			},
+		},
+		"spec": {"containers": [{
+			"command": ["kube-apiserver", "--advertise-address=192.168.49.2", "--anonymous-auth=false"],
+			"image": "busybox",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

Adds rules for session 1.2 API Server (up to 1.2.30, for now 1.2.31 and 1.2.32 are not included). This is my first time writing opa, let me know if you see anything that can be improved.


https://github.com/aquasecurity/trivy/issues/2200


cisbenchmark version: V1.23
```
"KCV0001": "1.2.1 Ensure that the --anonymous-auth argument is set to false (Manual)",
"KCV0002": "1.2.2 Ensure that the --token-auth-file parameter is not set (Automated)",
"KCV0003": "1.2.3 Ensure that the --DenyServiceExternalIPs is not set (Automated)",
"KCV0004": "1.2.4 Ensure that the --kubelet-https argument is set to true (Automated)",
"KCV0005": "1.2.5 Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)",
"KCV0006": "1.2.6 Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)",
"KCV0007": "1.2.7 Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)",
"KCV0008": "1.2.8 Ensure that the --authorization-mode argument includes Node (Automated)",
"KCV0009": "1.2.9 Ensure that the --authorization-mode argument includes RBAC (Automated)",
"KCV0010": "1.2.10 Ensure that the admission control plugin EventRateLimit is set (Manual)",
"KCV0011": "1.2.11 Ensure that the admission control plugin AlwaysAdmit is not set (Automated)",
"KCV0012": "1.2.12 Ensure that the admission control plugin AlwaysPullImages is set (Manual)",
"KCV0013": "1.2.13 Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)",
"KCV0014": "1.2.14 Ensure that the admission control plugin ServiceAccount is set (Automated)",
"KCV0015": "1.2.15 Ensure that the admission control plugin NamespaceLifecycle is set (Automated)",
"KCV0016": "1.2.16 Ensure that the admission control plugin NodeRestriction is set (Automated)",
"KCV0017": "1.2.17 Ensure that the --secure-port argument is not set to 0 (Automated)",
"KCV0018": "1.2.18 Ensure that the --profiling argument is set to false (Automated)",
"KCV0019": "1.2.19 Ensure that the --audit-log-path argument is set (Automated)",
"KCV0020": "1.2.20 Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)",
"KCV0021": "1.2.21 Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)",
"KCV0022": "1.2.22 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)",
"KCV0024": "1.2.24 Ensure that the --service-account-lookup argument is set to true (Automated)",
"KCV0025": "1.2.25 Ensure that the --service-account-key-file argument is set as appropriate (Automated)",
"KCV0026": "1.2.26 Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)",
"KCV0027": "1.2.27 Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)",
"KCV0028": "1.2.28 Ensure that the --client-ca-file argument is set as appropriate (Automated)",
"KCV0029": "1.2.29 Ensure that the --etcd-cafile argument is set as appropriate (Automated)",
"KCV0030": "1.2.30 Ensure that the --encryption-provider-config argument is set as appropriate (Manual)",
```