### PR TITLE
Fix: handle integers for Chart name in Helm parsing

### DIFF
--- a/pkg/scanners/helm/parser/parser.go
+++ b/pkg/scanners/helm/parser/parser.go
@@ -149,7 +149,7 @@ func (p *Parser) extractChartName(chartPath string) error {
 	if name, ok := chartContent["name"]; !ok {
 		return fmt.Errorf("could not extract the chart name from %s", chartPath)
 	} else {
-		p.helmClient.ReleaseName = name.(string)
+		p.helmClient.ReleaseName = fmt.Sprintf("%v", name)
 	}
 	return nil
 }

--- a/pkg/scanners/helm/test/parser_test.go
+++ b/pkg/scanners/helm/test/parser_test.go
@@ -50,6 +50,29 @@ func Test_helm_parser(t *testing.T) {
 	}
 }
 
+func Test_helm_parser_where_name_non_string(t *testing.T) {
+
+	tests := []struct {
+		testName  string
+		chartName string
+	}{
+		{
+			testName:  "Scanning chart with integer for name",
+			chartName: "numberName",
+		},
+	}
+
+	for _, test := range tests {
+		chartName := test.chartName
+
+		t.Logf("Running test: %s", test.testName)
+
+		helmParser := parser.New(chartName)
+		err := helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
+		require.NoError(t, err)
+	}
+}
+
 func Test_tar_is_chart(t *testing.T) {
 
 	tests := []struct {

--- a/pkg/scanners/helm/test/testdata/numberName/Chart.yaml
+++ b/pkg/scanners/helm/test/testdata/numberName/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: 1001
+version: 1.0.0


### PR DESCRIPTION
Related to https://github.com/aquasecurity/trivy#2459
