### PR TITLE
feat: Add framework classification capability for rules

### DIFF
--- a/internal/rules/register.go
+++ b/internal/rules/register.go
@@ -90,7 +90,7 @@ func (r *registry) deregister(rule RegisteredRule) {
 	}
 }
 
-func (r *registry) GetFrameworkRules(fw ...framework.Framework) []RegisteredRule {
+func (r *registry) getFrameworkRules(fw ...framework.Framework) []RegisteredRule {
 	r.RLock()
 	defer r.RUnlock()
 	var registered []RegisteredRule
@@ -117,5 +117,5 @@ func (r *registry) Reset() {
 }
 
 func GetFrameworkRules(fw ...framework.Framework) []RegisteredRule {
-	return coreRegistry.GetFrameworkRules(fw...)
+	return coreRegistry.getFrameworkRules(fw...)
 }

--- a/internal/rules/register.go
+++ b/internal/rules/register.go
@@ -1,13 +1,12 @@
 package rules
 
 import (
+	"sync"
+
+	"github.com/aquasecurity/defsec/pkg/framework"
 	"github.com/aquasecurity/defsec/pkg/scan"
 	"github.com/aquasecurity/defsec/pkg/state"
 )
-
-var registeredRules []RegisteredRule
-
-var index int
 
 type RegisteredRule struct {
 	number    int
@@ -30,28 +29,6 @@ func (r RegisteredRule) Evaluate(s *state.State) scan.Results {
 	return results
 }
 
-func Register(rule scan.Rule, f scan.CheckFunc) RegisteredRule {
-	registeredRule := RegisteredRule{
-		number:    index,
-		rule:      rule,
-		checkFunc: f,
-	}
-	index++
-
-	registeredRules = append(registeredRules, registeredRule)
-
-	return registeredRule
-}
-
-func Deregister(rule RegisteredRule) {
-	for i, registered := range registeredRules {
-		if registered.number == rule.number {
-			registeredRules = append(registeredRules[:i], registeredRules[i+1:]...)
-			return
-		}
-	}
-}
-
 func (r RegisteredRule) Rule() scan.Rule {
 	return r.rule
 }
@@ -60,6 +37,85 @@ func (r *RegisteredRule) AddLink(link string) {
 	r.rule.Links = append([]string{link}, r.rule.Links...)
 }
 
-func GetRegistered() []RegisteredRule {
-	return registeredRules
+type registry struct {
+	sync.RWMutex
+	index      int
+	frameworks map[framework.Framework][]RegisteredRule
+}
+
+var coreRegistry = registry{
+	frameworks: make(map[framework.Framework][]RegisteredRule),
+}
+
+func Reset() {
+	coreRegistry.Reset()
+}
+
+func Register(rule scan.Rule, f scan.CheckFunc) RegisteredRule {
+	return coreRegistry.register(rule, f)
+}
+
+func Deregister(rule RegisteredRule) {
+	coreRegistry.deregister(rule)
+}
+
+func (r *registry) register(rule scan.Rule, f scan.CheckFunc) RegisteredRule {
+	r.Lock()
+	defer r.Unlock()
+	if len(rule.Frameworks) == 0 {
+		rule.Frameworks = []framework.Framework{framework.Default}
+	}
+	registeredRule := RegisteredRule{
+		number:    r.index,
+		rule:      rule,
+		checkFunc: f,
+	}
+	r.index++
+	for _, fw := range rule.Frameworks {
+		r.frameworks[fw] = append(r.frameworks[fw], registeredRule)
+	}
+	return registeredRule
+}
+
+func (r *registry) deregister(rule RegisteredRule) {
+	r.Lock()
+	defer r.Unlock()
+	for fw := range r.frameworks {
+		for i, registered := range r.frameworks[fw] {
+			if registered.number == rule.number {
+				r.frameworks[fw] = append(r.frameworks[fw][:i], r.frameworks[fw][i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+func (r *registry) GetFrameworkRules(fw ...framework.Framework) []RegisteredRule {
+	r.RLock()
+	defer r.RUnlock()
+	var registered []RegisteredRule
+	if len(fw) == 0 {
+		fw = []framework.Framework{framework.Default}
+	}
+	unique := make(map[int]struct{})
+	for _, f := range fw {
+		for _, rule := range r.frameworks[f] {
+			if _, ok := unique[rule.number]; ok {
+				continue
+			}
+			registered = append(registered, rule)
+			unique[rule.number] = struct{}{}
+		}
+	}
+	return registered
+}
+
+func (r *registry) Reset() {
+	r.Lock()
+	defer r.Unlock()
+	r.frameworks = make(map[framework.Framework][]RegisteredRule)
+}
+
+func GetFrameworkRules(fw ...framework.Framework) []RegisteredRule {
+	return coreRegistry.GetFrameworkRules(fw...)
 }

--- a/internal/rules/register_test.go
+++ b/internal/rules/register_test.go
@@ -1,0 +1,134 @@
+package rules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/defsec/pkg/framework"
+	"github.com/aquasecurity/defsec/pkg/scan"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Reset(t *testing.T) {
+	rule := scan.Rule{}
+	_ = Register(rule, nil)
+	assert.Equal(t, 1, len(GetFrameworkRules()))
+	Reset()
+	assert.Equal(t, 0, len(GetFrameworkRules()))
+}
+
+func Test_Registration(t *testing.T) {
+	var tests = []struct {
+		name                 string
+		registeredFrameworks []framework.Framework
+		inputFrameworks      []framework.Framework
+		expected             bool
+	}{
+		{
+			name:     "rule without framework specified should be returned when no frameworks are requested",
+			expected: true,
+		},
+		{
+			name:            "rule without framework specified should not be returned when a specific framework is requested",
+			inputFrameworks: []framework.Framework{framework.CISC},
+			expected:        false,
+		},
+		{
+			name:            "rule without framework specified should be returned when the default framework is requested",
+			inputFrameworks: []framework.Framework{framework.Default},
+			expected:        true,
+		},
+		{
+			name:                 "rule with default framework specified should be returned when the default framework is requested",
+			registeredFrameworks: []framework.Framework{framework.Default},
+			inputFrameworks:      []framework.Framework{framework.Default},
+			expected:             true,
+		},
+		{
+			name:                 "rule with default framework specified should not be returned when a specific framework is requested",
+			registeredFrameworks: []framework.Framework{framework.Default},
+			inputFrameworks:      []framework.Framework{framework.CISC},
+			expected:             false,
+		},
+		{
+			name:                 "rule with specific framework specified should not be returned when a default framework is requested",
+			registeredFrameworks: []framework.Framework{framework.CISC},
+			inputFrameworks:      []framework.Framework{framework.Default},
+			expected:             false,
+		},
+		{
+			name:                 "rule with specific framework specified should be returned when the specific framework is requested",
+			registeredFrameworks: []framework.Framework{framework.CISC},
+			inputFrameworks:      []framework.Framework{framework.CISC},
+			expected:             true,
+		},
+		{
+			name:                 "rule with multiple frameworks specified should be returned when the specific framework is requested",
+			registeredFrameworks: []framework.Framework{framework.CISC, "blah"},
+			inputFrameworks:      []framework.Framework{framework.CISC},
+			expected:             true,
+		},
+		{
+			name:                 "rule with multiple frameworks specified should be returned only once when multiple matching frameworks are requested",
+			registeredFrameworks: []framework.Framework{framework.CISC, "blah", "something"},
+			inputFrameworks:      []framework.Framework{framework.CISC, "blah", "other"},
+			expected:             true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Reset()
+			rule := scan.Rule{
+				AVDID:      fmt.Sprintf("%d-%s", i, test.name),
+				Frameworks: test.registeredFrameworks,
+			}
+			_ = Register(rule, nil)
+			var found bool
+			for _, matchedRule := range GetFrameworkRules(test.inputFrameworks...) {
+				if matchedRule.Rule().AVDID == rule.AVDID {
+					assert.False(t, found, "rule should not be returned more than once")
+					found = true
+				}
+			}
+			assert.Equal(t, test.expected, found, "rule should be returned if it matches any of the input frameworks")
+		})
+	}
+}
+
+func Test_Deregistration(t *testing.T) {
+	Reset()
+	registrationA := Register(scan.Rule{
+		AVDID: "A",
+	}, nil)
+	registrationB := Register(scan.Rule{
+		AVDID: "B",
+	}, nil)
+	assert.Equal(t, 2, len(GetFrameworkRules()))
+	Deregister(registrationA)
+	actual := GetFrameworkRules()
+	require.Equal(t, 1, len(actual))
+	assert.Equal(t, "B", actual[0].Rule().AVDID)
+	Deregister(registrationB)
+	assert.Equal(t, 0, len(GetFrameworkRules()))
+}
+
+func Test_DeregistrationMultipleFrameworks(t *testing.T) {
+	Reset()
+	registrationA := Register(scan.Rule{
+		AVDID: "A",
+	}, nil)
+	registrationB := Register(scan.Rule{
+		AVDID:      "B",
+		Frameworks: []framework.Framework{"a", "b", "c", framework.Default},
+	}, nil)
+	assert.Equal(t, 2, len(GetFrameworkRules()))
+	Deregister(registrationA)
+	actual := GetFrameworkRules()
+	require.Equal(t, 1, len(actual))
+	assert.Equal(t, "B", actual[0].Rule().AVDID)
+	Deregister(registrationB)
+	assert.Equal(t, 0, len(GetFrameworkRules()))
+}

--- a/pkg/framework/frameworks.go
+++ b/pkg/framework/frameworks.go
@@ -1,0 +1,9 @@
+package framework
+
+type Framework string
+
+const (
+	Default      Framework = "default"
+	Experimental Framework = "experimental"
+	CISC         Framework = "cisc"
+)

--- a/pkg/rego/embed_test.go
+++ b/pkg/rego/embed_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_EmbeddedLoading(t *testing.T) {
 
-	rules := rules.GetRegistered()
+	rules := rules.GetFrameworkRules()
 	var found bool
 	for _, rule := range rules {
 		if rule.Rule().RegoPackage != "" {

--- a/pkg/rules/providers.go
+++ b/pkg/rules/providers.go
@@ -24,7 +24,7 @@ type Check struct {
 
 func GetProvidersHierarchy() (providers map[string]map[string][]string) {
 
-	registeredRules := rules.GetRegistered()
+	registeredRules := rules.GetFrameworkRules()
 
 	provs := make(map[string]map[string][]string)
 
@@ -54,7 +54,7 @@ func GetProvidersHierarchy() (providers map[string]map[string][]string) {
 
 func GetProviders() (providers []Provider) {
 
-	registeredRules := rules.GetRegistered()
+	registeredRules := rules.GetFrameworkRules()
 
 	provs := make(map[string]map[string][]Check)
 
@@ -106,7 +106,7 @@ func GetProvidersAsJson() ([]byte, error) {
 
 func GetProviderNames() []string {
 
-	registeredRules := rules.GetRegistered()
+	registeredRules := rules.GetFrameworkRules()
 
 	providers := make(map[string]bool)
 
@@ -129,7 +129,7 @@ func GetProviderNames() []string {
 
 func GetProviderServiceNames(providerName string) []string {
 
-	registeredRules := rules.GetRegistered()
+	registeredRules := rules.GetFrameworkRules()
 
 	services := make(map[string]bool)
 
@@ -154,7 +154,7 @@ func GetProviderServiceNames(providerName string) []string {
 
 func GetProviderServiceCheckNames(providerName string, serviceName string) []string {
 
-	registeredRules := rules.GetRegistered()
+	registeredRules := rules.GetFrameworkRules()
 
 	var checks []string
 

--- a/pkg/rules/register.go
+++ b/pkg/rules/register.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/aquasecurity/defsec/internal/rules"
+	"github.com/aquasecurity/defsec/pkg/framework"
 	"github.com/aquasecurity/defsec/pkg/scan"
 )
 
@@ -9,6 +10,6 @@ func Register(rule scan.Rule, f scan.CheckFunc) rules.RegisteredRule {
 	return rules.Register(rule, f)
 }
 
-func GetRegistered() (registered []rules.RegisteredRule) {
-	return rules.GetFrameworkRules()
+func GetRegistered(fw ...framework.Framework) (registered []rules.RegisteredRule) {
+	return rules.GetFrameworkRules(fw...)
 }

--- a/pkg/rules/register.go
+++ b/pkg/rules/register.go
@@ -10,5 +10,5 @@ func Register(rule scan.Rule, f scan.CheckFunc) rules.RegisteredRule {
 }
 
 func GetRegistered() (registered []rules.RegisteredRule) {
-	return rules.GetRegistered()
+	return rules.GetFrameworkRules()
 }

--- a/pkg/scan/rule.go
+++ b/pkg/scan/rule.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/aquasecurity/defsec/pkg/framework"
+
 	"golang.org/x/text/language"
 
 	"golang.org/x/text/cases"
@@ -39,21 +41,22 @@ type TerraformCustomCheck struct {
 }
 
 type Rule struct {
-	AVDID          string             `json:"avd_id"`
-	LegacyID       string             `json:"id"`
-	ShortCode      string             `json:"short_code"`
-	Summary        string             `json:"summary"`
-	Explanation    string             `json:"explanation"`
-	Impact         string             `json:"impact"`
-	Resolution     string             `json:"resolution"`
-	Provider       providers.Provider `json:"provider"`
-	Service        string             `json:"service"`
-	Links          []string           `json:"links"`
-	Severity       severity.Severity  `json:"severity"`
-	Terraform      *EngineMetadata    `json:"terraform,omitempty"`
-	CloudFormation *EngineMetadata    `json:"cloud_formation,omitempty"`
-	CustomChecks   CustomChecks       `json:"-"`
-	RegoPackage    string             `json:"-"`
+	AVDID          string                `json:"avd_id"`
+	LegacyID       string                `json:"id"`
+	ShortCode      string                `json:"short_code"`
+	Summary        string                `json:"summary"`
+	Explanation    string                `json:"explanation"`
+	Impact         string                `json:"impact"`
+	Resolution     string                `json:"resolution"`
+	Provider       providers.Provider    `json:"provider"`
+	Service        string                `json:"service"`
+	Links          []string              `json:"links"`
+	Severity       severity.Severity     `json:"severity"`
+	Terraform      *EngineMetadata       `json:"terraform,omitempty"`
+	CloudFormation *EngineMetadata       `json:"cloud_formation,omitempty"`
+	CustomChecks   CustomChecks          `json:"-"`
+	RegoPackage    string                `json:"-"`
+	Frameworks     []framework.Framework `json:"frameworks"`
 }
 
 func (r Rule) LongID() string {

--- a/pkg/scanners/cloudformation/scanner.go
+++ b/pkg/scanners/cloudformation/scanner.go
@@ -167,7 +167,7 @@ func (s *Scanner) scanFileContext(ctx context.Context, regoScanner *rego.Scanner
 		return nil, nil
 	}
 	if !s.regoOnly {
-		for _, rule := range rules.GetRegistered() {
+		for _, rule := range rules.GetFrameworkRules() {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()

--- a/test/performance_test.go
+++ b/test/performance_test.go
@@ -46,7 +46,7 @@ module "something" {
 }
 `
 
-	for _, rule := range rules.GetRegistered() {
+	for _, rule := range rules.GetFrameworkRules() {
 		if rule.Rule().Terraform == nil {
 			continue
 		}

--- a/test/rules_test.go
+++ b/test/rules_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAVDIDs(t *testing.T) {
 	existing := make(map[string]struct{})
-	for _, rule := range rules.GetRegistered() {
+	for _, rule := range rules.GetFrameworkRules() {
 		t.Run(rule.Rule().LongID(), func(t *testing.T) {
 			if rule.Rule().AVDID == "" {
 				t.Errorf("Rule has no AVD ID: %#v", rule)
@@ -33,7 +33,7 @@ func TestAVDIDs(t *testing.T) {
 }
 
 func TestRulesAgainstExampleCode(t *testing.T) {
-	for _, rule := range rules.GetRegistered() {
+	for _, rule := range rules.GetFrameworkRules() {
 		testName := fmt.Sprintf("%s/%s", rule.Rule().AVDID, rule.Rule().LongID())
 		t.Run(testName, func(t *testing.T) {
 			rule := rule


### PR DESCRIPTION
Backward compatible.

All rules are registered to the `default` framework by default. Specifying anything in the list of frameworks for a rule will cause it to be removed from the `default` framework unless `default` is explicitly specified in the list.

Rules can be requested for zero or more frameworks. Rules are returned which exist in any of the the supplied frameworks. If no frameworks are requested, rules for the `default` framework will be returned.