### PR TITLE
fix: add configmap support to k8s scanner

### DIFF
--- a/pkg/detection/detect.go
+++ b/pkg/detection/detect.go
@@ -174,13 +174,19 @@ func init() {
 			return false
 		}
 
-		expectedProperties := []string{"apiVersion", "kind", "metadata", "spec"}
+		expectedProperties := []string{"apiVersion", "kind", "metadata"}
 
 		if IsType(name, r, FileTypeJSON) {
 			var result map[string]interface{}
 			if err := json.Unmarshal(contents, &result); err != nil {
 				return false
 			}
+
+			// ignoring rbac because it has its own scanner
+			if _, ok := result["rules"]; ok {
+				return false
+			}
+
 			for _, expected := range expectedProperties {
 				if _, ok := result[expected]; !ok {
 					return false
@@ -199,6 +205,10 @@ func init() {
 			var result map[string]interface{}
 			if err := yaml.Unmarshal([]byte(partial), &result); err != nil {
 				continue
+			}
+			// ignoring rbac because it has its own scanner
+			if _, ok := result["rules"]; ok {
+				return false
 			}
 			match := true
 			for _, expected := range expectedProperties {

--- a/pkg/detection/detect_test.go
+++ b/pkg/detection/detect_test.go
@@ -225,6 +225,50 @@ spec:
 				FileTypeJSON,
 			},
 		},
+		{
+			name: "kubernetes, configmap",
+			path: "k8s.yml",
+			r: strings.NewReader(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default
+data:
+  AWS_ACCESS_KEY_ID: "XXX"
+  AWS_SECRET_ACCESS_KEY: "XXX"`),
+			expected: []FileType{
+				FileTypeKubernetes,
+				FileTypeYAML,
+			},
+		},
+		{
+			name: "rbac, reader",
+			path: "rbac.yml",
+			r: strings.NewReader(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: view
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch`),
+			expected: []FileType{
+				FileTypeRbac,
+				FileTypeYAML,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

Add support to kubernetes configmap detection. Instead of testing specifically for ConfigMap, I opted to only test for "apiVersion", "kind", "metadata" to detect if a yaml is k8s or not, though I'm it is ignoring rbac because it has its own scanner. This means, others resources would also be detected as K8S, like secrets, endpoints, endpointslices etc, which I think it is okay because they are k8s objects. So, actually what this PR does is to stop detecting only workloads. 

Let me know what you think please. We want trivy-operator to be able to report on ConfigMaps. 