### PR TITLE
feat: Add exclude-ignores flag and --config-file attribute

### DIFF
--- a/pkg/scanners/terraform/executor/executor.go
+++ b/pkg/scanners/terraform/executor/executor.go
@@ -175,17 +175,17 @@ func (e *Executor) Execute(modules terraform.Modules) (scan.Results, Metrics, er
 	return results, metrics, nil
 }
 
-func (e *Executor) removeExcludedIgnores(ignores terraform.Ignores) terraform.Ignores{
+func (e *Executor) removeExcludedIgnores(ignores terraform.Ignores) terraform.Ignores {
 	var filteredIgnores terraform.Ignores
-		for _, ignore := range ignores {
-			if !contains(e.excludeIgnoresIDs, ignore.RuleID) {
-				filteredIgnores = append(filteredIgnores, ignore)
-			}
+	for _, ignore := range ignores {
+		if !contains(e.excludeIgnoresIDs, ignore.RuleID) {
+			filteredIgnores = append(filteredIgnores, ignore)
 		}
+	}
 	return filteredIgnores
 }
 
-func contains( arr []string, s string) bool {
+func contains(arr []string, s string) bool {
 	for _, elem := range arr {
 		if elem == s {
 			return true

--- a/pkg/scanners/terraform/executor/executor.go
+++ b/pkg/scanners/terraform/executor/executor.go
@@ -26,6 +26,7 @@ import (
 type Executor struct {
 	enableIgnores             bool
 	excludedRuleIDs           []string
+	excludeIgnoresIDs         []string
 	includedRuleIDs           []string
 	ignoreCheckErrors         bool
 	workspaceName             string
@@ -127,6 +128,8 @@ func (e *Executor) Execute(modules terraform.Modules) (scan.Results, Metrics, er
 			ignores = append(ignores, module.Ignores()...)
 		}
 
+		ignores = e.removeExcludedIgnores(ignores)
+
 		for i, result := range results {
 			allIDs := []string{
 				result.Rule().LongID(),
@@ -170,6 +173,25 @@ func (e *Executor) Execute(modules terraform.Modules) (scan.Results, Metrics, er
 
 	e.sortResults(results)
 	return results, metrics, nil
+}
+
+func (e *Executor) removeExcludedIgnores(ignores terraform.Ignores) terraform.Ignores{
+	var filteredIgnores terraform.Ignores
+		for _, ignore := range ignores {
+			if !contains(e.excludeIgnoresIDs, ignore.RuleID) {
+				filteredIgnores = append(filteredIgnores, ignore)
+			}
+		}
+	return filteredIgnores
+}
+
+func contains( arr []string, s string) bool {
+	for _, elem := range arr {
+		if elem == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Executor) updateSeverity(results []scan.Result) scan.Results {

--- a/pkg/scanners/terraform/executor/option.go
+++ b/pkg/scanners/terraform/executor/option.go
@@ -50,6 +50,12 @@ func OptionExcludeRules(ruleIDs []string) Option {
 	}
 }
 
+func OptionExcludeIgnores(ruleIDs []string) Option {
+	return func(s *Executor) {
+		s.excludeIgnoresIDs = ruleIDs
+	}
+}
+
 func OptionIncludeRules(ruleIDs []string) Option {
 	return func(s *Executor) {
 		s.includedRuleIDs = ruleIDs

--- a/pkg/scanners/terraform/options.go
+++ b/pkg/scanners/terraform/options.go
@@ -59,6 +59,14 @@ func ScannerWithExcludedRules(ruleIDs []string) options.ScannerOption {
 	}
 }
 
+func ScannerWithExcludeIgnores(ruleIDs []string) options.ScannerOption {
+	return func(s options.ConfigurableScanner) {
+		if tf, ok := s.(ConfigurableTerraformScanner); ok {
+			tf.AddExecutorOptions(executor.OptionExcludeIgnores(ruleIDs))
+		}
+	}
+}
+
 func ScannerWithIncludedRules(ruleIDs []string) options.ScannerOption {
 	return func(s options.ConfigurableScanner) {
 		if tf, ok := s.(ConfigurableTerraformScanner); ok {


### PR DESCRIPTION
This is intended for adding `exclude-ignores` flag and --config-file attribute.

In some cases, we want to enforce some rules and remove the ability to `#tfsec:ignore`

Follow up PR for tfsec:
https://github.com/aquasecurity/tfsec/pull/1839