### PR TITLE
fix(rego): Allow quotes in working directories for Dockerfiles

### DIFF
--- a/internal/rules/docker/policies/workdir_path_not_absolute.rego
+++ b/internal/rules/docker/policies/workdir_path_not_absolute.rego
@@ -23,7 +23,7 @@ get_work_dir[output] {
 	workdir := docker.workdir[_]
 	arg := workdir.Value[0]
 
-	not regex.match("(^/[A-z0-9-_+]*)|(^[A-z0-9-_+]:\\\\.*)|(^\\$[{}A-z0-9-_+].*)", arg)
+	not regex.match("^[\"']?(/[A-z0-9-_+]*)|([A-z0-9-_+]:\\\\.*)|(\\$[{}A-z0-9-_+].*)", arg)
 	output := {
 		"cmd": workdir,
 		"arg": arg,

--- a/internal/rules/docker/policies/workdir_path_not_absolute_test.rego
+++ b/internal/rules/docker/policies/workdir_path_not_absolute_test.rego
@@ -54,3 +54,22 @@ test_absolute_work_dir_allowed {
 
 	count(r) == 0
 }
+
+test_absolute_work_dir_with_quotes_allowed {
+	r := deny with input as {"Stages": [{"Name": "alpine:3.3", "Commands": [
+		{
+			"Cmd": "from",
+			"Value": ["alpine:3.3"],
+		},
+		{
+			"Cmd": "run",
+			"Value": ["apk --no-cache add nginx"],
+		},
+		{
+			"Cmd": "workdir",
+			"Value": ["\"/path/to/workdir\""],
+		},
+	]}]}
+
+	count(r) == 0
+}


### PR DESCRIPTION
Relates to https://github.com/aquasecurity/trivy/issues/2622

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>