### PR TITLE
fix: Add the aliases into the ignores to support moved rules

### DIFF
--- a/pkg/scanners/helm/scanner.go
+++ b/pkg/scanners/helm/scanner.go
@@ -171,7 +171,7 @@ func (s *Scanner) getScanResults(path string, ctx context.Context, target fs.FS)
 			return nil, fmt.Errorf("unmarshal yaml: %w", err)
 		}
 		for _, manifest := range manifests {
-			fileResults, err := regoScanner.ScanInput(context.Background(), rego.Input{
+			fileResults, err := regoScanner.ScanInput(ctx, rego.Input{
 				Path:     file.TemplateFilePath,
 				Contents: manifest,
 				Type:     types.SourceKubernetes,

--- a/pkg/scanners/terraform/executor/executor.go
+++ b/pkg/scanners/terraform/executor/executor.go
@@ -138,6 +138,8 @@ func (e *Executor) Execute(modules terraform.Modules) (scan.Results, Metrics, er
 				result.Rule().LongID(),
 				result.Rule().AVDID,
 			}
+			allIDs = append(allIDs, result.Rule().Aliases...)
+
 			if e.alternativeIDProviderFunc != nil {
 				allIDs = append(allIDs, e.alternativeIDProviderFunc(result.Rule().LongID())...)
 			}

--- a/test/ignore_test.go
+++ b/test/ignore_test.go
@@ -21,6 +21,7 @@ var exampleRule = scan.Rule{
 	Provider:  providers.AWSProvider,
 	Service:   "service",
 	ShortCode: "abc123",
+	Aliases:   []string{"aws-other-abc123"},
 	Severity:  severity.High,
 	CustomChecks: scan.CustomChecks{
 		Terraform: &scan.TerraformCustomCheck{
@@ -325,4 +326,17 @@ resource "bad" "my-rule" {
 }
 `, "testworkspace")
 	assert.Len(t, results.GetFailed(), 1)
+}
+
+func Test_IgnoreWithAliasCodeStillIgnored(t *testing.T) {
+	reg := rules.Register(exampleRule, nil)
+	defer rules.Deregister(reg)
+
+	results := scanHCLWithWorkspace(t, `
+# tfsec:ignore:aws-other-abc123
+resource "bad" "my-rule" {
+	
+}
+`, "testworkspace")
+	assert.Len(t, results.GetFailed(), 0)
 }


### PR DESCRIPTION
Contributes towards https://github.com/aquasecurity/tfsec/issues/1842

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
