### PR TITLE
fix: Allow singular failures when scanning cloud resources

### DIFF
--- a/internal/adapters/cloud/aws/api-gateway/apis_v1.go
+++ b/internal/adapters/cloud/aws/api-gateway/apis_v1.go
@@ -35,7 +35,8 @@ func (a *adapter) getAPIsV1() ([]v1.API, error) {
 	for _, restAPI := range apiRestApis {
 		adaptedAPI, err := a.adaptRestAPIV1(restAPI)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt v1 API '%s': %s", *restAPI.Id, err)
+			continue
 		}
 		adapted = append(adapted, *adaptedAPI)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/api-gateway/apis_v2.go
+++ b/internal/adapters/cloud/aws/api-gateway/apis_v2.go
@@ -35,7 +35,8 @@ func (a *adapter) getAPIsV2() ([]v2.API, error) {
 	for _, restAPI := range apiApis {
 		adaptedAPI, err := a.adaptAPIV2(restAPI)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt v2 API '%s': %s", *restAPI.ApiId, err)
+			continue
 		}
 		adapted = append(adapted, *adaptedAPI)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/athena/adapt.go
+++ b/internal/adapters/cloud/aws/athena/adapt.go
@@ -73,7 +73,8 @@ func (a *adapter) getWorkgroups() ([]athena.Workgroup, error) {
 	for _, apiWorkgroup := range apiWorkgroups {
 		workgroup, err := a.adaptWorkgroup(apiWorkgroup)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt workgroup '%s': %s", workgroup.Name, err)
+			continue
 		}
 		workgroups = append(workgroups, *workgroup)
 		a.Tracker().IncrementResource()
@@ -172,7 +173,8 @@ func (a *adapter) getDatabasesForCatalogue(catalogueName string) ([]athena.Datab
 	for _, apiDatabase := range apiDatabases {
 		catalogue, err := a.adaptDatabase(apiDatabase)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt database '%s': %s", *apiDatabase.Name, err)
+			continue
 		}
 		databases = append(databases, *catalogue)
 	}

--- a/internal/adapters/cloud/aws/cloudfront/adapt.go
+++ b/internal/adapters/cloud/aws/cloudfront/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getDistributions() ([]cloudfront.Distribution, error) {
 	for _, apiDistribution := range apiDistributions {
 		distribution, err := a.adaptDistribution(apiDistribution)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt distribution '%s': %s", *apiDistribution.ARN, err)
+			continue
 		}
 		distributions = append(distributions, *distribution)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/cloudwatch/adapt.go
+++ b/internal/adapters/cloud/aws/cloudwatch/adapt.go
@@ -73,7 +73,8 @@ func (a *adapter) getAlarms() ([]cloudwatch.Alarm, error) {
 	for _, apiAlarm := range apiAlarms {
 		alarm, err := a.adaptAlarm(apiAlarm)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt alarm '%s': %s", *apiAlarm.AlarmArn, err)
+			continue
 		}
 		alarms = append(alarms, *alarm)
 		a.Tracker().IncrementResource()
@@ -104,10 +105,11 @@ func (a *adapter) getLogGroups() ([]cloudwatch.LogGroup, error) {
 	a.Tracker().SetServiceLabel("Adapting log groups...")
 
 	var logGroups []cloudwatch.LogGroup
-	for _, apiDistribution := range apiLogGroups {
-		logGroup, err := a.adaptLogGroup(apiDistribution)
+	for _, apiGroup := range apiLogGroups {
+		logGroup, err := a.adaptLogGroup(apiGroup)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt log group '%s': %s", *apiGroup.Arn, err)
+			continue
 		}
 		logGroups = append(logGroups, *logGroup)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/codebuild/adapt.go
+++ b/internal/adapters/cloud/aws/codebuild/adapt.go
@@ -64,7 +64,8 @@ func (a *adapter) getProjects() ([]codebuild.Project, error) {
 	for _, projectName := range projectNames {
 		logGroup, err := a.adaptProject(projectName)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt project '%s': %s", projectName, err)
+			continue
 		}
 		projects = append(projects, *logGroup)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/documentdb/adapt.go
+++ b/internal/adapters/cloud/aws/documentdb/adapt.go
@@ -63,11 +63,12 @@ func (a *adapter) getClusters() ([]documentdb.Cluster, error) {
 
 	var clusters []documentdb.Cluster
 	for _, apiCluster := range apiClusters {
-		logGroup, err := a.adaptCluster(apiCluster)
+		cluster, err := a.adaptCluster(apiCluster)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", *apiCluster.DBClusterArn, err)
+			continue
 		}
-		clusters = append(clusters, *logGroup)
+		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()
 	}
 

--- a/internal/adapters/cloud/aws/dynamodb/dynamodb.go
+++ b/internal/adapters/cloud/aws/dynamodb/dynamodb.go
@@ -82,6 +82,7 @@ func (a *adapter) getTableBatch(token *string) (tables []dynamodb.Table, nextTok
 			TableName: aws.String(apiTable),
 		})
 		if err != nil {
+			a.Debug("Failed to adapt table '%s': %s", apiTable, err)
 			continue
 		}
 

--- a/internal/adapters/cloud/aws/ecr/adapt.go
+++ b/internal/adapters/cloud/aws/ecr/adapt.go
@@ -68,7 +68,8 @@ func (a *adapter) getRepositories() ([]ecr.Repository, error) {
 	for _, apiRepository := range apiRepositories {
 		repository, err := a.adaptRepository(apiRepository)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt repository '%s': %s", *apiRepository.RepositoryArn, err)
+			continue
 		}
 		repositories = append(repositories, *repository)
 		a.Tracker().IncrementResource()
@@ -109,6 +110,7 @@ func (a *adapter) adaptRepository(apiRepository types.Repository) (*ecr.Reposito
 				Metadata: metadata,
 				Parsed:   *parsed,
 			},
+			Builtin: defsecTypes.Bool(false, metadata),
 		})
 	}
 

--- a/internal/adapters/cloud/aws/ecs/cluster.go
+++ b/internal/adapters/cloud/aws/ecs/cluster.go
@@ -37,7 +37,8 @@ func (a *adapter) getClusters() ([]ecs.Cluster, error) {
 	for _, clusterARN := range clusterARNs {
 		cluster, err := a.adaptCluster(clusterARN)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", cluster, err)
+			continue
 		}
 		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/ecs/task.go
+++ b/internal/adapters/cloud/aws/ecs/task.go
@@ -31,7 +31,8 @@ func (a *adapter) getTaskDefinitions() ([]ecs.TaskDefinition, error) {
 	for _, definitionARN := range definitionARNs {
 		definition, err := a.adaptTaskDefinition(definitionARN)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt task definition '%s': %s", definitionARN, err)
+			continue
 		}
 		definitions = append(definitions, *definition)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/efs/adapt.go
+++ b/internal/adapters/cloud/aws/efs/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getFilesystems() ([]efs.FileSystem, error) {
 	for _, apiFilesystem := range apiFilesystems {
 		filesystem, err := a.adaptFilesystem(apiFilesystem)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt filesystem '%s': %s", *apiFilesystem.FileSystemArn, err)
+			continue
 		}
 		filesystems = append(filesystems, *filesystem)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/eks/adapt.go
+++ b/internal/adapters/cloud/aws/eks/adapt.go
@@ -63,10 +63,11 @@ func (a *adapter) getClusters() ([]eks.Cluster, error) {
 
 	var clusters []eks.Cluster
 
-	for _, arn := range clusterNames {
-		cluster, err := a.adaptCluster(arn)
+	for _, clusterName := range clusterNames {
+		cluster, err := a.adaptCluster(clusterName)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", clusterName, err)
+			continue
 		}
 		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/elasticache/adapt.go
+++ b/internal/adapters/cloud/aws/elasticache/adapt.go
@@ -73,7 +73,8 @@ func (a *adapter) getClusters() ([]elasticache.Cluster, error) {
 	for _, apiCluster := range apiClusters {
 		cluster, err := a.adaptCluster(apiCluster)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", *apiCluster.ARN, err)
+			continue
 		}
 		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()
@@ -117,7 +118,8 @@ func (a *adapter) getReplicationGroups() ([]elasticache.ReplicationGroup, error)
 	for _, apiGroup := range apiGroups {
 		group, err := a.adaptReplicationGroup(apiGroup)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt replication group '%s': %s", *apiGroup.ARN, err)
+			continue
 		}
 		groups = append(groups, *group)
 		a.Tracker().IncrementResource()
@@ -160,7 +162,8 @@ func (a *adapter) getSecurityGroups() ([]elasticache.SecurityGroup, error) {
 	for _, apiGroup := range apiGroups {
 		group, err := a.adaptSecurityGroup(apiGroup)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt security group '%s': %s", *apiGroup.ARN, err)
+			continue
 		}
 		groups = append(groups, *group)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/elasticsearch/adapt.go
+++ b/internal/adapters/cloud/aws/elasticsearch/adapt.go
@@ -58,7 +58,8 @@ func (a *adapter) getDomains() ([]elasticsearch.Domain, error) {
 	for _, apiDomain := range apiDomains {
 		domain, err := a.adaptDomain(apiDomain)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt domain '%s': %s", *apiDomain.DomainName, err)
+			continue
 		}
 		domains = append(domains, *domain)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/elb/adapt.go
+++ b/internal/adapters/cloud/aws/elb/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getLoadBalancers() ([]elb.LoadBalancer, error) {
 	for _, apiLoadBalancer := range apiLoadBalancers {
 		loadBalancer, err := a.adaptLoadBalancer(apiLoadBalancer)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt load balancer '%s': %s", *apiLoadBalancer.LoadBalancerArn, err)
+			continue
 		}
 		loadBalancers = append(loadBalancers, *loadBalancer)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/emr/adapt.go
+++ b/internal/adapters/cloud/aws/emr/adapt.go
@@ -125,7 +125,8 @@ func (a *adapter) getSecurityConfigurations() ([]emr.SecurityConfiguration, erro
 	for _, apiConfig := range apiConfigs {
 		config, err := a.adaptConfig(apiConfig)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt security configuration '%s': %s", *apiConfig.Name, err)
+			continue
 		}
 		configs = append(configs, *config)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/iam/group.go
+++ b/internal/adapters/cloud/aws/iam/group.go
@@ -36,7 +36,8 @@ func (a *adapter) adaptGroups(state *state.State) error {
 	for _, apiGroup := range nativeGroups {
 		group, err := a.adaptGroup(apiGroup, state)
 		if err != nil {
-			return err
+			a.Debug("Failed to adapt group '%s': %s", *apiGroup.Arn, err)
+			continue
 		}
 		state.AWS.IAM.Groups = append(state.AWS.IAM.Groups, *group)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/iam/iam.go
+++ b/internal/adapters/cloud/aws/iam/iam.go
@@ -60,6 +60,7 @@ func (a *adapter) adaptPasswordPolicy(state *state.State) error {
 
 	output, err := a.api.GetAccountPasswordPolicy(a.Context(), &iamapi.GetAccountPasswordPolicyInput{})
 	if err != nil {
+		a.Debug("Failed to adapt account password policy: %s", err)
 		return nil
 	}
 	a.Tracker().SetTotalResources(1)

--- a/internal/adapters/cloud/aws/iam/policy.go
+++ b/internal/adapters/cloud/aws/iam/policy.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/liamg/iamgo"
 
@@ -39,7 +40,8 @@ func (a *adapter) adaptPolicies(state *state.State) error {
 	for _, apiPolicy := range nativePolicies {
 		policy, err := a.adaptPolicy(apiPolicy)
 		if err != nil {
-			return err
+			a.Debug("Failed to adapt policy '%s': %s", *apiPolicy.Arn, err)
+			continue
 		}
 		state.AWS.IAM.Policies = append(state.AWS.IAM.Policies, *policy)
 		a.Tracker().IncrementResource()
@@ -78,6 +80,7 @@ func (a *adapter) adaptPolicy(apiPolicy iamtypes.Policy) (*iam.Policy, error) {
 			Metadata: metadata,
 			Parsed:   *document,
 		},
+		Builtin: types.Bool(strings.HasPrefix(*apiPolicy.Arn, "arn:aws:iam::aws:"), metadata),
 	}, nil
 }
 

--- a/internal/adapters/cloud/aws/iam/role.go
+++ b/internal/adapters/cloud/aws/iam/role.go
@@ -36,7 +36,8 @@ func (a *adapter) adaptRoles(state *state.State) error {
 	for _, apiRole := range nativeRoles {
 		user, err := a.adaptRole(apiRole)
 		if err != nil {
-			return err
+			a.Debug("Failed to adapt role '%s': %s", *apiRole.Arn, err)
+			continue
 		}
 		state.AWS.IAM.Roles = append(state.AWS.IAM.Roles, *user)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/iam/user.go
+++ b/internal/adapters/cloud/aws/iam/user.go
@@ -37,7 +37,8 @@ func (a *adapter) adaptUsers(state *state.State) error {
 	for _, apiUser := range nativeUsers {
 		user, err := a.adaptUser(apiUser)
 		if err != nil {
-			return err
+			a.Debug("Failed to adapt user '%s': %s", *apiUser.Arn, err)
+			continue
 		}
 		state.AWS.IAM.Users = append(state.AWS.IAM.Users, *user)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/kinesis/adapt.go
+++ b/internal/adapters/cloud/aws/kinesis/adapt.go
@@ -66,7 +66,8 @@ func (a *adapter) getStreams() ([]kinesis.Stream, error) {
 		if lastName != apiStream {
 			stream, err := a.adaptStream(apiStream)
 			if err != nil {
-				return nil, err
+				a.Debug("Failed to adapt stream '%s': %s", apiStream, err)
+				continue
 			}
 			streams = append(streams, *stream)
 		}

--- a/internal/adapters/cloud/aws/kms/adapt.go
+++ b/internal/adapters/cloud/aws/kms/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getKeys() ([]kms.Key, error) {
 	for _, apiKey := range apiKeys {
 		key, err := a.adaptKey(apiKey)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt key '%s': %s", *apiKey.KeyArn, err)
+			continue
 		}
 		keys = append(keys, *key)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/lambda/adapt.go
+++ b/internal/adapters/cloud/aws/lambda/adapt.go
@@ -72,7 +72,8 @@ func (a *adapter) getFunctions() ([]lambda.Function, error) {
 	for _, apiFunction := range apiFunctions {
 		function, err := a.adaptFunction(apiFunction)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt function '%s': %s", *apiFunction.FunctionArn, err)
+			continue
 		}
 		functions = append(functions, *function)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/mq/adapt.go
+++ b/internal/adapters/cloud/aws/mq/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getBrokers() ([]mq.Broker, error) {
 	for _, apiBroker := range apiBrokers {
 		broker, err := a.adaptBroker(apiBroker)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt broker '%s': %s", *apiBroker.BrokerArn, err)
+			continue
 		}
 		brokers = append(brokers, *broker)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/msk/adapt.go
+++ b/internal/adapters/cloud/aws/msk/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getClusters() ([]msk.Cluster, error) {
 	for _, apiCluster := range apiClusters {
 		cluster, err := a.adaptCluster(apiCluster)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", *apiCluster.ClusterArn, err)
+			continue
 		}
 		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/neptune/adapt.go
+++ b/internal/adapters/cloud/aws/neptune/adapt.go
@@ -65,7 +65,8 @@ func (a *adapter) getClusters() ([]neptune.Cluster, error) {
 	for _, apiCluster := range apiClusters {
 		cluster, err := a.adaptCluster(apiCluster)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", *apiCluster.DBClusterArn, err)
+			continue
 		}
 		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/rds/rds.go
+++ b/internal/adapters/cloud/aws/rds/rds.go
@@ -44,7 +44,8 @@ func (a adapter) Adapt(root *aws2.RootAdapter, state *state.State) error {
 
 	state.AWS.RDS.Classic, err = a.getClassic()
 	if err != nil {
-		return err
+		a.Debug("Failed to retrieve classic resource: %s", err)
+		return nil
 	}
 
 	return nil

--- a/internal/adapters/cloud/aws/redshift/adapt.go
+++ b/internal/adapters/cloud/aws/redshift/adapt.go
@@ -38,7 +38,11 @@ func (a *adapter) Adapt(root *aws.RootAdapter, state *state.State) error {
 	}
 
 	// this can error is classic resources are used where disabled
-	state.AWS.Redshift.SecurityGroups, _ = a.getSecurityGroups()
+	state.AWS.Redshift.SecurityGroups, err = a.getSecurityGroups()
+	if err != nil {
+		a.Debug("Failed to adapt security groups: %s", err)
+		return nil
+	}
 
 	return nil
 }
@@ -68,7 +72,8 @@ func (a *adapter) getClusters() ([]redshift.Cluster, error) {
 	for _, apiCluster := range apiClusters {
 		cluster, err := a.adaptCluster(apiCluster)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt cluster '%s': %s", *apiCluster.ClusterNamespaceArn, err)
+			continue
 		}
 		clusters = append(clusters, *cluster)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/sns/sns.go
+++ b/internal/adapters/cloud/aws/sns/sns.go
@@ -83,7 +83,8 @@ func (a *adapter) getBatchTopics(token *string) (topics []sns.Topic, nextToken *
 			TopicArn: topic.TopicArn,
 		})
 		if err != nil {
-			return topics, nil, err
+			a.Debug("Failed to get topic attributes for '%s': %s", *topic.TopicArn, err)
+			continue
 		}
 
 		if kmsKeyID, ok := topicAttributes.Attributes["KmsMasterKeyId"]; ok {

--- a/internal/adapters/cloud/aws/sqs/sqs.go
+++ b/internal/adapters/cloud/aws/sqs/sqs.go
@@ -123,6 +123,7 @@ func (a *adapter) getQueueBatch(token *string) (queues []sqs.Queue, nextToken *s
 						Metadata: queueMetadata,
 						Parsed:   *policy,
 					},
+					Builtin: types.Bool(false, queueMetadata),
 				})
 
 			}

--- a/internal/adapters/cloud/aws/ssm/adapt.go
+++ b/internal/adapters/cloud/aws/ssm/adapt.go
@@ -62,10 +62,11 @@ func (a *adapter) getSecrets() ([]ssm.Secret, error) {
 	a.Tracker().SetServiceLabel("Adapting secrets...")
 
 	var secrets []ssm.Secret
-	for _, apiCluster := range apiSecrets {
-		secret, err := a.adaptSecret(apiCluster)
+	for _, apiSecret := range apiSecrets {
+		secret, err := a.adaptSecret(apiSecret)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt secret '%s': %s", *apiSecret.ARN, err)
+			continue
 		}
 		secrets = append(secrets, *secret)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloud/aws/workspaces/adapt.go
+++ b/internal/adapters/cloud/aws/workspaces/adapt.go
@@ -62,10 +62,11 @@ func (a *adapter) getWorkspaces() ([]workspaces.WorkSpace, error) {
 	a.Tracker().SetServiceLabel("Adapting workspaces...")
 
 	var spaces []workspaces.WorkSpace
-	for _, apiCluster := range apiSecrets {
-		workspace, err := a.adaptWorkspace(apiCluster)
+	for _, apiWorkspace := range apiSecrets {
+		workspace, err := a.adaptWorkspace(apiWorkspace)
 		if err != nil {
-			return nil, err
+			a.Debug("Failed to adapt workspace '%s': %s", *apiWorkspace.WorkspaceId, err)
+			continue
 		}
 		spaces = append(spaces, *workspace)
 		a.Tracker().IncrementResource()

--- a/internal/adapters/cloudformation/aws/ecr/repository.go
+++ b/internal/adapters/cloudformation/aws/ecr/repository.go
@@ -77,6 +77,7 @@ func getPolicy(r *parser.Resource) (*iam.Policy, error) {
 			Metadata: policyProp.Metadata(),
 			Parsed:   *parsed,
 		},
+		Builtin: types.Bool(false, policyProp.Metadata()),
 	}, nil
 }
 

--- a/internal/adapters/cloudformation/aws/iam/policy.go
+++ b/internal/adapters/cloudformation/aws/iam/policy.go
@@ -17,6 +17,7 @@ func getPolicies(ctx parser.FileContext) (policies []iam.Policy) {
 				Metadata: policyResource.Metadata(),
 				Parsed:   iamgo.Document{},
 			},
+			Builtin: types.Bool(false, policyResource.Metadata()),
 		}
 
 		if policyProp := policyResource.GetProperty("PolicyDocument"); policyProp.IsNotNil() {
@@ -117,6 +118,7 @@ func getPoliciesDocs(policiesProp *parser.Property) []iam.Policy {
 				Metadata: policyProp.Metadata(),
 				Parsed:   *doc,
 			},
+			Builtin: types.Bool(false, policyProp.Metadata()),
 		})
 	}
 	return policies

--- a/internal/adapters/cloudformation/aws/sam/function.go
+++ b/internal/adapters/cloudformation/aws/sam/function.go
@@ -46,6 +46,7 @@ func setFunctionPolicies(r *parser.Resource, function *sam.Function) {
 							Metadata: property.Metadata(),
 							Parsed:   *parsed,
 						},
+						Builtin: types.Bool(false, property.Metadata()),
 					}
 					function.Policies = append(function.Policies, policy)
 				} else if property.IsString() {

--- a/internal/adapters/cloudformation/aws/sam/state_machines.go
+++ b/internal/adapters/cloudformation/aws/sam/state_machines.go
@@ -71,6 +71,7 @@ func setStateMachinePolicies(r *parser.Resource, stateMachine *sam.StateMachine)
 						Metadata: property.Metadata(),
 						Parsed:   *parsed,
 					},
+					Builtin: types.Bool(false, property.Metadata()),
 				}
 				stateMachine.Policies = append(stateMachine.Policies, policy)
 			}

--- a/internal/adapters/cloudformation/aws/sqs/queue.go
+++ b/internal/adapters/cloudformation/aws/sqs/queue.go
@@ -57,6 +57,7 @@ func getPolicy(id string, ctx parser.FileContext) (*iam.Policy, error) {
 						Metadata: documentProp.Metadata(),
 						Parsed:   *parsed,
 					},
+					Builtin: types.Bool(false, documentProp.Metadata()),
 				}, nil
 			}
 		}

--- a/internal/adapters/terraform/aws/ecr/adapt.go
+++ b/internal/adapters/terraform/aws/ecr/adapt.go
@@ -69,6 +69,7 @@ func adaptRepository(resource *terraform.Block, module *terraform.Module) ecr.Re
 					Parsed:   *parsed,
 					Metadata: policyAttr.GetMetadata(),
 				},
+				Builtin: types.Bool(false, policyRes.GetMetadata()),
 			}
 
 			repo.Policies = append(repo.Policies, policy)

--- a/internal/adapters/terraform/aws/ecr/adapt_test.go
+++ b/internal/adapters/terraform/aws/ecr/adapt_test.go
@@ -124,6 +124,7 @@ func Test_adaptRepository(t *testing.T) {
 								Metadata: types.NewTestMetadata(),
 							}
 						}(),
+						Builtin: types.Bool(false, types.NewTestMetadata()),
 					},
 				},
 			},

--- a/internal/adapters/terraform/aws/iam/groups_test.go
+++ b/internal/adapters/terraform/aws/iam/groups_test.go
@@ -76,6 +76,7 @@ func Test_adaptGroups(t *testing.T) {
 									HasRefs:  false,
 								}
 							}(),
+							Builtin: types.Bool(false, types.NewTestMetadata()),
 						},
 					},
 				},

--- a/internal/adapters/terraform/aws/iam/policies.go
+++ b/internal/adapters/terraform/aws/iam/policies.go
@@ -37,6 +37,7 @@ func parsePolicy(policyBlock *terraform.Block, modules terraform.Modules) (iam.P
 			IsOffset: false,
 			HasRefs:  false,
 		},
+		Builtin: types.Bool(false, policyBlock.GetMetadata()),
 	}
 	var err error
 	doc, err := ParsePolicyFromAttr(policyBlock.GetAttribute("policy"), policyBlock, modules)
@@ -58,6 +59,7 @@ func adaptPolicies(modules terraform.Modules) (policies []iam.Policy) {
 				IsOffset: false,
 				HasRefs:  false,
 			},
+			Builtin: types.Bool(false, policyBlock.GetMetadata()),
 		}
 		doc, err := ParsePolicyFromAttr(policyBlock.GetAttribute("policy"), policyBlock, modules)
 		if err != nil {

--- a/internal/adapters/terraform/aws/iam/policies_test.go
+++ b/internal/adapters/terraform/aws/iam/policies_test.go
@@ -62,6 +62,7 @@ func Test_adaptPolicies(t *testing.T) {
 							HasRefs:  false,
 						}
 					}(),
+					Builtin: types.Bool(false, types.NewTestMetadata()),
 				},
 			},
 		},

--- a/internal/adapters/terraform/aws/iam/roles.go
+++ b/internal/adapters/terraform/aws/iam/roles.go
@@ -58,6 +58,7 @@ func mapRoles(modules terraform.Modules) (map[string]iam.Role, map[string]struct
 					IsOffset: false,
 					HasRefs:  false,
 				},
+				Builtin: types.Bool(false, inlineBlock.GetMetadata()),
 			}
 			doc, err := ParsePolicyFromAttr(inlineBlock.GetAttribute("policy"), inlineBlock, modules)
 			if err != nil {

--- a/internal/adapters/terraform/aws/iam/users_test.go
+++ b/internal/adapters/terraform/aws/iam/users_test.go
@@ -74,6 +74,7 @@ func Test_adaptUsers(t *testing.T) {
 									HasRefs:  false,
 								}
 							}(),
+							Builtin: types.Bool(false, types.NewTestMetadata()),
 						},
 					},
 				},

--- a/internal/adapters/terraform/aws/s3/adapt_test.go
+++ b/internal/adapters/terraform/aws/s3/adapt_test.go
@@ -228,6 +228,7 @@ func Test_Adapt(t *testing.T) {
 										HasRefs:  false,
 									}
 								}(),
+								Builtin: types.Bool(false, types.NewTestMetadata()),
 							},
 						},
 						Encryption: s3.Encryption{

--- a/internal/adapters/terraform/aws/s3/policies.go
+++ b/internal/adapters/terraform/aws/s3/policies.go
@@ -23,6 +23,7 @@ func (a *adapter) adaptBucketPolicies() {
 			Metadata: policyAttr.GetMetadata(),
 			Name:     types.StringDefault("", b.GetMetadata()),
 			Document: *doc,
+			Builtin:  types.Bool(false, b.GetMetadata()),
 		}
 
 		var bucketName string

--- a/internal/adapters/terraform/aws/sqs/adapt.go
+++ b/internal/adapters/terraform/aws/sqs/adapt.go
@@ -38,6 +38,7 @@ func (a *adapter) adaptQueues() []sqs.Queue {
 			Document: iamp.Document{
 				Metadata: policyBlock.GetMetadata(),
 			},
+			Builtin: types.Bool(false, policyBlock.GetMetadata()),
 		}
 		if attr := policyBlock.GetAttribute("policy"); attr.IsString() {
 			parsed, err := iamgo.ParseString(attr.Value().AsString())
@@ -98,6 +99,7 @@ func (a *adapter) adaptQueue(resource *terraform.Block) {
 			Document: iamp.Document{
 				Metadata: attr.GetMetadata(),
 			},
+			Builtin: types.Bool(false, attr.GetMetadata()),
 		}
 		parsed, err := iamgo.ParseString(attr.Value().AsString())
 		if err == nil {
@@ -116,6 +118,7 @@ func (a *adapter) adaptQueue(resource *terraform.Block) {
 						Metadata: doc.Source.GetMetadata(),
 						Parsed:   doc.Document,
 					},
+					Builtin: types.Bool(false, refBlock.GetMetadata()),
 				}
 				policies = append(policies, policy)
 			}

--- a/internal/adapters/terraform/aws/sqs/adapt_test.go
+++ b/internal/adapters/terraform/aws/sqs/adapt_test.go
@@ -66,6 +66,7 @@ func Test_Adapt(t *testing.T) {
 										Metadata: types.NewTestMetadata(),
 										Parsed:   builder.Build(),
 									},
+									Builtin: types.Bool(false, types.NewTestMetadata()),
 								},
 							}
 						}(),

--- a/internal/lint/adapter/testdata/src/code/alias.go
+++ b/internal/lint/adapter/testdata/src/code/alias.go
@@ -1,0 +1,13 @@
+package code
+
+import (
+	x "provider"
+	y "types"
+)
+
+func DoAnotherThing() x.Thing {
+	thing := x.Thing{ // want "Provider struct provider.Thing is missing an initialised value for field 'Other'"
+		Name: y.String{Value: "a name"},
+	}
+	return thing
+}

--- a/internal/rules/aws/iam/no_policy_wildcards.go
+++ b/internal/rules/aws/iam/no_policy_wildcards.go
@@ -47,20 +47,32 @@ var CheckNoPolicyWildcards = rules.Register(
 	},
 	func(s *state.State) (results scan.Results) {
 		for _, policy := range s.AWS.IAM.Policies {
+			if policy.Builtin.IsTrue() {
+				continue
+			}
 			results = checkPolicy(policy.Document, results)
 		}
 		for _, group := range s.AWS.IAM.Groups {
 			for _, policy := range group.Policies {
+				if policy.Builtin.IsTrue() {
+					continue
+				}
 				results = checkPolicy(policy.Document, results)
 			}
 		}
 		for _, user := range s.AWS.IAM.Users {
 			for _, policy := range user.Policies {
+				if policy.Builtin.IsTrue() {
+					continue
+				}
 				results = checkPolicy(policy.Document, results)
 			}
 		}
 		for _, role := range s.AWS.IAM.Roles {
 			for _, policy := range role.Policies {
+				if policy.Builtin.IsTrue() {
+					continue
+				}
 				results = checkPolicy(policy.Document, results)
 			}
 		}

--- a/internal/rules/aws/iam/no_policy_wildcards_test.go
+++ b/internal/rules/aws/iam/no_policy_wildcards_test.go
@@ -49,12 +49,49 @@ func TestCheckNoPolicyWildcards(t *testing.T) {
 										Metadata: types.NewTestMetadata(),
 									}
 								}(),
+								Builtin: types.Bool(false, types.NewTestMetadata()),
 							},
 						},
 					},
 				},
 			},
 			expected: true,
+		},
+		{
+			name: "Builtin IAM policy with wildcard resource",
+			input: iam.IAM{
+				Roles: []iam.Role{
+					{
+						Metadata: types.NewTestMetadata(),
+						Policies: []iam.Policy{
+							{
+								Metadata: types.NewTestMetadata(),
+								Document: func() iam.Document {
+
+									builder := iamgo.NewPolicyBuilder()
+									builder.WithVersion("2012-10-17")
+
+									sb := iamgo.NewStatementBuilder()
+									sb.WithSid("ListYourObjects")
+									sb.WithEffect(iamgo.EffectAllow)
+									sb.WithActions([]string{"s3:ListBucket"})
+									sb.WithResources([]string{"arn:aws:s3:::*"})
+									sb.WithAWSPrincipals([]string{"arn:aws:iam::1234567890:root"})
+
+									builder.WithStatement(sb.Build())
+
+									return iam.Document{
+										Parsed:   builder.Build(),
+										Metadata: types.NewTestMetadata(),
+									}
+								}(),
+								Builtin: types.Bool(true, types.NewTestMetadata()),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
 		},
 		{
 			name: "IAM policy with wildcard action",
@@ -81,6 +118,7 @@ func TestCheckNoPolicyWildcards(t *testing.T) {
 								Metadata: types.NewTestMetadata(),
 							}
 						}(),
+						Builtin: types.Bool(false, types.NewTestMetadata()),
 					},
 				},
 			},
@@ -110,6 +148,7 @@ func TestCheckNoPolicyWildcards(t *testing.T) {
 								Metadata: types.NewTestMetadata(),
 							}
 						}(),
+						Builtin: types.Bool(false, types.NewTestMetadata()),
 					},
 				},
 				Roles: []iam.Role{
@@ -135,6 +174,7 @@ func TestCheckNoPolicyWildcards(t *testing.T) {
 										Metadata: types.NewTestMetadata(),
 									}
 								}(),
+								Builtin: types.Bool(false, types.NewTestMetadata()),
 							},
 						},
 					},

--- a/pkg/providers/aws/iam/iam.go
+++ b/pkg/providers/aws/iam/iam.go
@@ -19,6 +19,7 @@ type Policy struct {
 	types.Metadata
 	Name     types.StringValue
 	Document Document
+	Builtin  types.BoolValue
 }
 
 type Document struct {

--- a/pkg/providers/aws/s3/bucket.go
+++ b/pkg/providers/aws/s3/bucket.go
@@ -16,12 +16,6 @@ type Bucket struct {
 	ACL               types.StringValue
 }
 
-func NewBucket(metadata types.Metadata) Bucket {
-	return Bucket{
-		Metadata: metadata,
-	}
-}
-
 func (b *Bucket) HasPublicExposureACL() bool {
 	for _, publicACL := range []string{"public-read", "public-read-write", "website", "authenticated-read"} {
 		if b.ACL.EqualTo(publicACL) {


### PR DESCRIPTION
- Allows retrieval of individual resources to fail when scanning cloud resources
- Ignores builtin policies when checking for IAM policy best-practices
- Ensure linting is applied for aliased packages
- Add debug logging whenever issues occur during cloud scanning