### PR TITLE
feat: distinguish failed and ignored for JUnit (#719)

### DIFF
--- a/pkg/formatters/junit.go
+++ b/pkg/formatters/junit.go
@@ -18,6 +18,7 @@ type jUnitTestSuite struct {
 	XMLName   xml.Name        `xml:"testsuite"`
 	Name      string          `xml:"name,attr"`
 	Failures  string          `xml:"failures,attr"`
+	Skipped   string          `xml:"skipped,attr,omitempty"`
 	Tests     string          `xml:"tests,attr"`
 	TestCases []jUnitTestCase `xml:"testcase"`
 }
@@ -29,6 +30,7 @@ type jUnitTestCase struct {
 	Name      string        `xml:"name,attr"`
 	Time      string        `xml:"time,attr"`
 	Failure   *jUnitFailure `xml:"failure,omitempty"`
+	Skipped   *jUnitSkipped `xml:"skipped,omitempty"`
 }
 
 // jUnitFailure contains data related to a failed test.
@@ -38,12 +40,21 @@ type jUnitFailure struct {
 	Contents string `xml:",chardata"`
 }
 
-func outputJUnit(b ConfigurableFormatter, results scan.Results) error {
+// jUnitSkipped defines a not executed test.
+type jUnitSkipped struct {
+	Message string `xml:"message,attr,omitempty"`
+}
 
+func outputJUnit(b ConfigurableFormatter, results scan.Results) error {
 	output := jUnitTestSuite{
 		Name:     filepath.Base(os.Args[0]),
-		Failures: fmt.Sprintf("%d", len(results)-countPassedResults(results)),
+		Failures: fmt.Sprintf("%d", countWithStatus(results, scan.StatusFailed)),
 		Tests:    fmt.Sprintf("%d", len(results)),
+	}
+
+	skipped := countWithStatus(results, scan.StatusIgnored)
+	if skipped > 0 {
+		output.Skipped = fmt.Sprintf("%d", skipped)
 	}
 
 	for _, res := range results {
@@ -64,6 +75,7 @@ func outputJUnit(b ConfigurableFormatter, results scan.Results) error {
 				Name:      fmt.Sprintf("[%s][%s] - %s", res.Rule().LongID(), res.Severity(), res.Description()),
 				Time:      "0",
 				Failure:   buildFailure(b, res),
+				Skipped:   buildSkipped(res),
 			},
 		)
 	}
@@ -94,7 +106,7 @@ func highlightCodeJunit(res scan.Result) string {
 }
 
 func buildFailure(b ConfigurableFormatter, res scan.Result) *jUnitFailure {
-	if res.Status() == scan.StatusPassed {
+	if res.Status() != scan.StatusFailed {
 		return nil
 	}
 
@@ -120,14 +132,23 @@ func buildFailure(b ConfigurableFormatter, res scan.Result) *jUnitFailure {
 	}
 }
 
-func countPassedResults(results []scan.Result) int {
-	passed := 0
+func buildSkipped(res scan.Result) *jUnitSkipped {
+	if res.Status() != scan.StatusIgnored {
+		return nil
+	}
+	return &jUnitSkipped{
+		Message: res.Description(),
+	}
+}
+
+func countWithStatus(results []scan.Result, status scan.Status) int {
+	count := 0
 
 	for _, res := range results {
-		if res.Status() == scan.StatusPassed {
-			passed++
+		if res.Status() == status {
+			count++
 		}
 	}
 
-	return passed
+	return count
 }


### PR DESCRIPTION
Previously all not passed scan results were treated as a failure by the
JUnit formatter. This was a problem for e.g. tfsec, since with a JUnit
result viewer there was no way to distinguish between ignored tests and
actually failed ones.

Now "ignored" scan results are marked as "skipped".

Additionally, a test for passed scans has been added as well. It already
worked as intended, but so far we had no test to ensure this.