### PR TITLE
fix(terraform): Fix queue logging of azure storage account being detected when no queues are used

### DIFF
--- a/internal/adapters/terraform/azure/storage/adapt.go
+++ b/internal/adapters/terraform/azure/storage/adapt.go
@@ -85,6 +85,13 @@ func adaptAccounts(modules terraform.Modules) ([]storage.Account, []string, []st
 				accountedForNetworkRules = append(accountedForNetworkRules, networkRuleBlock.ID())
 				account.NetworkRules = append(account.NetworkRules, adaptNetworkRule(networkRuleBlock))
 			}
+			for _, queueBlock := range module.GetReferencingResources(resource, "azurerm_storage_queue", "storage_account_name") {
+				queue := storage.Queue{
+					Metadata: queueBlock.GetMetadata(),
+					Name:     queueBlock.GetAttribute("name").AsStringValueOrDefault("", queueBlock),
+				}
+				account.Queues = append(account.Queues, queue)
+			}
 			accounts = append(accounts, account)
 		}
 	}

--- a/internal/rules/azure/storage/queue_services_logging_enabled.go
+++ b/internal/rules/azure/storage/queue_services_logging_enabled.go
@@ -35,7 +35,7 @@ Requests are logged on a best-effort basis.`,
 	},
 	func(s *state.State) (results scan.Results) {
 		for _, account := range s.Azure.Storage.Accounts {
-			if account.IsUnmanaged() {
+			if account.IsUnmanaged() || len(account.Queues) == 0 {
 				continue
 			}
 			if account.QueueProperties.EnableLogging.IsFalse() {

--- a/internal/rules/azure/storage/queue_services_logging_enabled.tf.go
+++ b/internal/rules/azure/storage/queue_services_logging_enabled.tf.go
@@ -32,6 +32,11 @@ var terraformQueueServicesLoggingEnabledBadExamples = []string{
      queue_properties  {
    }
  }
+
+  resource "azurerm_storage_queue" "bad_example" {
+	 name                 = "my-queue"
+	 storage_account_name  = azurerm_storage_account.bad_example.name
+  }
  `,
 }
 

--- a/internal/rules/azure/storage/queue_services_logging_enabled_test.go
+++ b/internal/rules/azure/storage/queue_services_logging_enabled_test.go
@@ -29,10 +29,31 @@ func TestCheckQueueServicesLoggingEnabled(t *testing.T) {
 							Metadata:      defsecTypes.NewTestMetadata(),
 							EnableLogging: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
 						},
+						Queues: []storage.Queue{
+							{
+								Metadata: defsecTypes.NewTestMetadata(),
+								Name:     defsecTypes.String("my-queue", defsecTypes.NewTestMetadata()),
+							},
+						},
 					},
 				},
 			},
 			expected: true,
+		},
+		{
+			name: "Storage account queue properties logging disabled with no queues",
+			input: storage.Storage{
+				Accounts: []storage.Account{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						QueueProperties: storage.QueueProperties{
+							Metadata:      defsecTypes.NewTestMetadata(),
+							EnableLogging: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
+						},
+					},
+				},
+			},
+			expected: false,
 		},
 		{
 			name: "Storage account queue properties logging enabled",

--- a/pkg/providers/azure/storage/storage.go
+++ b/pkg/providers/azure/storage/storage.go
@@ -15,6 +15,12 @@ type Account struct {
 	Containers        []Container
 	QueueProperties   QueueProperties
 	MinimumTLSVersion defsecTypes.StringValue
+	Queues            []Queue
+}
+
+type Queue struct {
+	defsecTypes.Metadata
+	Name defsecTypes.StringValue
 }
 
 type QueueProperties struct {


### PR DESCRIPTION
Resolves #882

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>