### PR TITLE
feat: Add check for ensuring subnets don't provide public IPs by default

### DIFF
--- a/avd_docs/aws/ec2/AVD-AWS-0164/CloudFormation.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0164/CloudFormation.md
@@ -1,0 +1,14 @@
+
+Set the instance to not be publicly accessible
+
+```yaml
+---
+Resources:
+  GoodExample:
+    Properties:
+      VpcId: vpc-123456
+    Type: AWS::EC2::Subnet
+
+```
+
+

--- a/avd_docs/aws/ec2/AVD-AWS-0164/Terraform.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0164/Terraform.md
@@ -1,0 +1,14 @@
+
+Set the instance to not be publicly accessible
+
+```hcl
+ resource "aws_subnet" "good_example" {
+	vpc_id                  = "vpc-123456"
+	map_public_ip_on_launch = false
+ }
+ 
+```
+
+#### Remediation Links
+ - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch
+

--- a/avd_docs/aws/ec2/AVD-AWS-0164/docs.md
+++ b/avd_docs/aws/ec2/AVD-AWS-0164/docs.md
@@ -1,0 +1,13 @@
+
+You should limit the provision of public IP addresses for resources. Resources should not be exposed on the public internet, but should have access limited to consumers required for the function of your application.
+
+### Impact
+The instance is publicly accessible
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses
+
+

--- a/internal/adapters/cloudformation/aws/ec2/ec2.go
+++ b/internal/adapters/cloudformation/aws/ec2/ec2.go
@@ -14,6 +14,7 @@ func Adapt(cfFile parser.FileContext) ec2.EC2 {
 		DefaultVPCs:          nil,
 		NetworkACLs:          getNetworkACLs(cfFile),
 		SecurityGroups:       getSecurityGroups(cfFile),
+		Subnets:              getSubnets(cfFile),
 		Volumes:              getVolumes(cfFile),
 	}
 }

--- a/internal/adapters/cloudformation/aws/ec2/subnet.go
+++ b/internal/adapters/cloudformation/aws/ec2/subnet.go
@@ -1,0 +1,21 @@
+package ec2
+
+import (
+	"github.com/aquasecurity/defsec/pkg/providers/aws/ec2"
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/parser"
+)
+
+func getSubnets(ctx parser.FileContext) (subnets []ec2.Subnet) {
+
+	subnetResources := ctx.GetResourcesByType("AWS::EC2::Subnet")
+	for _, r := range subnetResources {
+
+		subnet := ec2.Subnet{
+			Metadata:            r.Metadata(),
+			MapPublicIpOnLaunch: r.GetBoolProperty("MapPublicIpOnLaunch"),
+		}
+
+		subnets = append(subnets, subnet)
+	}
+	return subnets
+}

--- a/internal/adapters/terraform/aws/ec2/adapt.go
+++ b/internal/adapters/terraform/aws/ec2/adapt.go
@@ -15,6 +15,7 @@ func Adapt(modules terraform.Modules) ec2.EC2 {
 		Instances:            getInstances(modules),
 		DefaultVPCs:          adaptDefaultVPCs(modules),
 		SecurityGroups:       sgAdapter.adaptSecurityGroups(modules),
+		Subnets:              adaptSubnets(modules),
 		NetworkACLs:          naclAdapter.adaptNetworkACLs(modules),
 		LaunchConfigurations: adaptLaunchConfigurations(modules),
 		LaunchTemplates:      adaptLaunchTemplates(modules),

--- a/internal/adapters/terraform/aws/ec2/subnet.go
+++ b/internal/adapters/terraform/aws/ec2/subnet.go
@@ -1,0 +1,26 @@
+package ec2
+
+import (
+	"github.com/aquasecurity/defsec/pkg/providers/aws/ec2"
+	"github.com/aquasecurity/defsec/pkg/terraform"
+)
+
+func adaptSubnets(modules terraform.Modules) []ec2.Subnet {
+	var subnets []ec2.Subnet
+	for _, module := range modules {
+		for _, resource := range module.GetResourcesByType("aws_subnet") {
+			subnets = append(subnets, adaptSubnet(resource, module))
+		}
+	}
+	return subnets
+}
+
+func adaptSubnet(resource *terraform.Block, module *terraform.Module) ec2.Subnet {
+	mapPublicIpOnLaunchAttr := resource.GetAttribute("map_public_ip_on_launch")
+	mapPublicIpOnLaunchVal := mapPublicIpOnLaunchAttr.AsBoolValueOrDefault(false, resource)
+
+	return ec2.Subnet{
+		Metadata:            resource.GetMetadata(),
+		MapPublicIpOnLaunch: mapPublicIpOnLaunchVal,
+	}
+}

--- a/internal/adapters/terraform/aws/ec2/subnet_test.go
+++ b/internal/adapters/terraform/aws/ec2/subnet_test.go
@@ -1,0 +1,90 @@
+package ec2
+
+import (
+	"testing"
+
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/providers/aws/ec2"
+
+	"github.com/aquasecurity/defsec/internal/adapters/terraform/tftestutil"
+
+	"github.com/aquasecurity/defsec/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_adaptSubnet(t *testing.T) {
+	tests := []struct {
+		name      string
+		terraform string
+		expected  ec2.Subnet
+	}{
+		{
+			name: "map public ip on launch is true",
+			terraform: `
+			resource "aws_subnet" "example" {
+				vpc_id                  = "vpc-123456"
+				map_public_ip_on_launch = true
+			}
+`,
+			expected: ec2.Subnet{
+				Metadata:            defsecTypes.NewTestMetadata(),
+				MapPublicIpOnLaunch: defsecTypes.Bool(true, defsecTypes.NewTestMetadata()),
+			},
+		},
+		{
+			name: "map public ip on launch is false",
+			terraform: `
+			resource "aws_subnet" "example" {
+				vpc_id                  = "vpc-123456"
+				map_public_ip_on_launch = false
+			}
+`,
+			expected: ec2.Subnet{
+				Metadata:            defsecTypes.NewTestMetadata(),
+				MapPublicIpOnLaunch: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
+			},
+		},
+		{
+			name: "defaults",
+			terraform: `
+			resource "aws_subnet" "example" {
+			    vpc_id = "vpc-123456"
+			}
+`,
+			expected: ec2.Subnet{
+				Metadata:            defsecTypes.NewTestMetadata(),
+				MapPublicIpOnLaunch: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules := tftestutil.CreateModulesFromSource(t, test.terraform, ".tf")
+			adapted := adaptSubnet(modules.GetBlocks()[0], modules[0])
+			testutil.AssertDefsecEqual(t, test.expected, adapted)
+		})
+	}
+}
+
+func TestSubnetLines(t *testing.T) {
+	src := `
+	resource "aws_subnet" "example" {
+	    vpc_id                  = "vpc-123456"
+	    map_public_ip_on_launch = true
+	}`
+
+	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
+	adapted := Adapt(modules)
+
+	require.Len(t, adapted.Subnets, 1)
+	subnet := adapted.Subnets[0]
+
+	assert.Equal(t, 2, subnet.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 5, subnet.GetMetadata().Range().GetEndLine())
+
+	assert.Equal(t, 4, subnet.MapPublicIpOnLaunch.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 4, subnet.MapPublicIpOnLaunch.GetMetadata().Range().GetEndLine())
+}

--- a/internal/rules/aws/ec2/no_public_ip_subnet.cf.go
+++ b/internal/rules/aws/ec2/no_public_ip_subnet.cf.go
@@ -1,0 +1,26 @@
+package ec2
+
+var cloudFormationNoPublicIpSubnetGoodExamples = []string{
+	`---
+Resources:
+  GoodExample:
+    Properties:
+      VpcId: vpc-123456
+    Type: AWS::EC2::Subnet
+`,
+}
+
+var cloudFormationNoPublicIpSubnetBadExamples = []string{
+	`---
+Resources:
+  BadExample:
+    Properties:
+      MapPublicIpOnLaunch: true
+      VpcId: vpc-123456
+    Type: AWS::EC2::Subnet
+`,
+}
+
+var cloudFormationNoPublicIpSubnetLinks = []string{}
+
+var cloudFormationNoPublicIpSubnetRemediationMarkdown = ``

--- a/internal/rules/aws/ec2/no_public_ip_subnet.go
+++ b/internal/rules/aws/ec2/no_public_ip_subnet.go
@@ -1,0 +1,52 @@
+package ec2
+
+import (
+	"github.com/aquasecurity/defsec/internal/rules"
+	"github.com/aquasecurity/defsec/pkg/providers"
+	"github.com/aquasecurity/defsec/pkg/scan"
+	"github.com/aquasecurity/defsec/pkg/severity"
+	"github.com/aquasecurity/defsec/pkg/state"
+)
+
+var CheckNoPublicIpSubnet = rules.Register(
+	scan.Rule{
+		AVDID:       "AVD-AWS-0164",
+		Aliases:     []string{"aws-subnet-no-public-ip"},
+		Provider:    providers.AWSProvider,
+		Service:     "ec2",
+		ShortCode:   "no-public-ip-subnet",
+		Summary:     "Instances in a subnet should not receive a public IP address by default.",
+		Impact:      "The instance is publicly accessible",
+		Resolution:  "Set the instance to not be publicly accessible",
+		Explanation: `You should limit the provision of public IP addresses for resources. Resources should not be exposed on the public internet, but should have access limited to consumers required for the function of your application.`,
+		Links: []string{
+			"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses",
+		},
+		Terraform: &scan.EngineMetadata{
+			GoodExamples:        terraformNoPublicIpSubnetGoodExamples,
+			BadExamples:         terraformNoPublicIpSubnetBadExamples,
+			Links:               terraformNoPublicIpSubnetLinks,
+			RemediationMarkdown: terraformNoPublicIpSubnetRemediationMarkdown,
+		},
+		CloudFormation: &scan.EngineMetadata{
+			GoodExamples:        cloudFormationNoPublicIpSubnetGoodExamples,
+			BadExamples:         cloudFormationNoPublicIpSubnetBadExamples,
+			Links:               cloudFormationNoPublicIpSubnetLinks,
+			RemediationMarkdown: cloudFormationNoPublicIpSubnetRemediationMarkdown,
+		},
+		Severity: severity.High,
+	},
+	func(s *state.State) (results scan.Results) {
+		for _, subnet := range s.AWS.EC2.Subnets {
+			if subnet.MapPublicIpOnLaunch.IsTrue() {
+				results.Add(
+					"Subnet associates public IP address.",
+					subnet.MapPublicIpOnLaunch,
+				)
+			} else {
+				results.AddPassed(&subnet)
+			}
+		}
+		return
+	},
+)

--- a/internal/rules/aws/ec2/no_public_ip_subnet.tf.go
+++ b/internal/rules/aws/ec2/no_public_ip_subnet.tf.go
@@ -1,0 +1,25 @@
+package ec2
+
+var terraformNoPublicIpSubnetGoodExamples = []string{
+	`
+ resource "aws_subnet" "good_example" {
+	vpc_id                  = "vpc-123456"
+	map_public_ip_on_launch = false
+ }
+ `,
+}
+
+var terraformNoPublicIpSubnetBadExamples = []string{
+	`
+ resource "aws_subnet" "bad_example" {
+	vpc_id                  = "vpc-123456"
+	map_public_ip_on_launch = true
+ }
+ `,
+}
+
+var terraformNoPublicIpSubnetLinks = []string{
+	`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch`,
+}
+
+var terraformNoPublicIpSubnetRemediationMarkdown = ``

--- a/internal/rules/aws/ec2/no_public_ip_subnet_test.go
+++ b/internal/rules/aws/ec2/no_public_ip_subnet_test.go
@@ -1,0 +1,65 @@
+package ec2
+
+import (
+	"testing"
+
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/providers/aws/ec2"
+	"github.com/aquasecurity/defsec/pkg/scan"
+
+	"github.com/aquasecurity/defsec/pkg/state"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckNoPublicIpSubnet(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    ec2.EC2
+		expected bool
+	}{
+		{
+			name: "Subnet with public access",
+			input: ec2.EC2{
+				Subnets: []ec2.Subnet{
+					{
+						Metadata:            defsecTypes.NewTestMetadata(),
+						MapPublicIpOnLaunch: defsecTypes.Bool(true, defsecTypes.NewTestMetadata()),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Subnet without public access",
+			input: ec2.EC2{
+				Subnets: []ec2.Subnet{
+					{
+						Metadata:            defsecTypes.NewTestMetadata(),
+						MapPublicIpOnLaunch: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var testState state.State
+			testState.AWS.EC2 = test.input
+			results := CheckNoPublicIpSubnet.Evaluate(&testState)
+			var found bool
+			for _, result := range results {
+				if result.Status() == scan.StatusFailed && result.Rule().LongID() == CheckNoPublicIpSubnet.Rule().LongID() {
+					found = true
+				}
+			}
+			if test.expected {
+				assert.True(t, found, "Rule should have been found")
+			} else {
+				assert.False(t, found, "Rule should not have been found")
+			}
+		})
+	}
+}

--- a/pkg/providers/aws/ec2/ec2.go
+++ b/pkg/providers/aws/ec2/ec2.go
@@ -7,5 +7,6 @@ type EC2 struct {
 	DefaultVPCs          []DefaultVPC
 	SecurityGroups       []SecurityGroup
 	NetworkACLs          []NetworkACL
+	Subnets              []Subnet
 	Volumes              []Volume
 }

--- a/pkg/providers/aws/ec2/subnet.go
+++ b/pkg/providers/aws/ec2/subnet.go
@@ -1,0 +1,10 @@
+package ec2
+
+import (
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+)
+
+type Subnet struct {
+	defsecTypes.Metadata
+	MapPublicIpOnLaunch defsecTypes.BoolValue
+}


### PR DESCRIPTION
Fixes #875.

`aws_subnet`: `map_public_ip_on_launch` should be `false`