### PR TITLE
fix: Readd policy wildcards rule to default framework

### DIFF
--- a/internal/rules/aws/iam/no_policy_wildcards.go
+++ b/internal/rules/aws/iam/no_policy_wildcards.go
@@ -27,6 +27,7 @@ var CheckNoPolicyWildcards = rules.Register(
 		Service:   "iam",
 		ShortCode: "no-policy-wildcards",
 		Frameworks: map[framework.Framework][]string{
+			framework.Default:     nil,
 			framework.CIS_AWS_1_4: {"1.16"},
 		},
 		Summary:     "IAM policy should avoid use of wildcards and instead apply the principle of least privilege",


### PR DESCRIPTION
See https://github.com/aquasecurity/defsec/issues/906#issuecomment-1252095523