### PR TITLE
fix: Conditions not supported in CloudFormation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,6 @@ jobs:
           cache-dependency-path: go.sum
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.47
+          version: v1.48
           skip-cache: true
           args: --timeout 10m --verbose

--- a/internal/adapters/terraform/aws/iam/convert.go
+++ b/internal/adapters/terraform/aws/iam/convert.go
@@ -114,7 +114,7 @@ func ConvertTerraformDocument(modules terraform.Modules, block *terraform.Block)
 	return &wrappedDocument{Document: builder.Build(), Source: block}, nil
 }
 
-//nolint
+// nolint
 func parseStatement(statementBlock *terraform.Block) iamgo.Statement {
 
 	metadata := statementBlock.GetMetadata()

--- a/internal/adapters/terraform/google/sql/adapt.go
+++ b/internal/adapters/terraform/google/sql/adapt.go
@@ -81,7 +81,7 @@ func adaptInstance(resource *terraform.Block) sql.DatabaseInstance {
 	return instance
 }
 
-//nolint
+// nolint
 func adaptFlags(resources terraform.Blocks, flags *sql.Flags) {
 	for _, resource := range resources {
 

--- a/internal/rules/aws/iam/no_policy_wildcards.go
+++ b/internal/rules/aws/iam/no_policy_wildcards.go
@@ -94,7 +94,7 @@ func checkPolicy(src iam.Document, results scan.Results) scan.Results {
 	return results
 }
 
-//nolint
+// nolint
 func checkStatement(src iam.Document, statement iamgo.Statement, results scan.Results) scan.Results {
 	effect, _ := statement.Effect()
 	if effect != iamgo.EffectAllow {

--- a/pkg/detection/detect.go
+++ b/pkg/detection/detect.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -81,7 +80,7 @@ func init() {
 				return false
 			}
 
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			if err != nil {
 				return false
 			}
@@ -114,7 +113,7 @@ func init() {
 			return false
 		}
 
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			return false
 		}
@@ -169,7 +168,7 @@ func init() {
 			return false
 		}
 
-		contents, err := ioutil.ReadAll(r)
+		contents, err := io.ReadAll(r)
 		if err != nil {
 			return false
 		}
@@ -233,7 +232,7 @@ func init() {
 			return false
 		}
 
-		contents, err := ioutil.ReadAll(r)
+		contents, err := io.ReadAll(r)
 		if err != nil {
 			return false
 		}
@@ -308,7 +307,7 @@ func ensureSeeker(r io.Reader) io.ReadSeeker {
 	if seeker, ok := r.(io.ReadSeeker); ok {
 		return seeker
 	}
-	if data, err := ioutil.ReadAll(r); err == nil {
+	if data, err := io.ReadAll(r); err == nil {
 		return bytes.NewReader(data)
 	}
 	return nil

--- a/pkg/rego/load.go
+++ b/pkg/rego/load.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -53,7 +52,7 @@ func (s *Scanner) loadPoliciesFromReaders(readers []io.Reader) (map[string]*ast.
 	modules := make(map[string]*ast.Module)
 	for i, r := range readers {
 		moduleName := fmt.Sprintf("reader_%d", i)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scan/code_test.go
+++ b/pkg/scan/code_test.go
@@ -74,8 +74,8 @@ func TestResult_GetCode(t *testing.T) {
 					Content: `resource "aws_s3_bucket" "something" {`,
 				},
 				{
-					Number: 2,
-					Content: `	bucket = "something"`,
+					Number:     2,
+					Content:    `	bucket = "something"`,
 					IsCause:    true,
 					FirstCause: true,
 					LastCause:  true,

--- a/pkg/scanners/cloudformation/parser/file_context.go
+++ b/pkg/scanners/cloudformation/parser/file_context.go
@@ -21,6 +21,7 @@ type FileContext struct {
 	Resources    map[string]*Resource   `json:"Resources" yaml:"Resources"`
 	Globals      map[string]*Resource   `json:"Globals" yaml:"Globals"`
 	Mappings     map[string]interface{} `json:"Mappings,omitempty" yaml:"Mappings"`
+	Conditions   map[string]Property    `json:"Conditions,omitempty" yaml:"Conditions"`
 }
 
 func (t *FileContext) GetResourceByLogicalID(name string) *Resource {

--- a/pkg/scanners/cloudformation/parser/fn_and.go
+++ b/pkg/scanners/cloudformation/parser/fn_and.go
@@ -1,0 +1,38 @@
+package parser
+
+import "github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+func ResolveAnd(property *Property) (resolved *Property, success bool) {
+	if !property.isFunction() {
+		return property, true
+	}
+
+	refValue := property.AsMap()["Fn::And"].AsList()
+
+	if len(refValue) < 2 {
+		return abortIntrinsic(property, "Fn::And should have at least 2 values, returning original Property")
+	}
+
+	results := make([]bool, len(refValue))
+	for i := 0; i < len(refValue); i++ {
+
+		r := false
+		if refValue[i].IsBool() {
+			r = refValue[i].AsBool()
+		}
+
+		results[i] = r
+	}
+
+	theSame := allSameStrings(results)
+	return property.deriveResolved(cftypes.Bool, theSame), true
+}
+
+func allSameStrings(a []bool) bool {
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[0] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/scanners/cloudformation/parser/fn_and_test.go
+++ b/pkg/scanners/cloudformation/parser/fn_and_test.go
@@ -1,0 +1,186 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_resolve_and_value(t *testing.T) {
+
+	property1 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	property2 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	andProperty := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::And": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							property1,
+							property2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(andProperty)
+	require.True(t, success)
+
+	assert.True(t, resolvedProperty.IsTrue())
+}
+
+func Test_resolve_and_value_not_the_same(t *testing.T) {
+
+	property1 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	property2 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	andProperty := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::And": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							property1,
+							property2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(andProperty)
+	require.True(t, success)
+
+	assert.False(t, resolvedProperty.IsTrue())
+}

--- a/pkg/scanners/cloudformation/parser/fn_equals.go
+++ b/pkg/scanners/cloudformation/parser/fn_equals.go
@@ -18,5 +18,4 @@ func ResolveEquals(property *Property) (resolved *Property, success bool) {
 	propA, _ := refValue[0].resolveValue()
 	propB, _ := refValue[1].resolveValue()
 	return property.deriveResolved(cftypes.Bool, propA.EqualTo(propB.RawValue())), true
-
 }

--- a/pkg/scanners/cloudformation/parser/fn_if.go
+++ b/pkg/scanners/cloudformation/parser/fn_if.go
@@ -1,0 +1,40 @@
+package parser
+
+func ResolveIf(property *Property) (resolved *Property, success bool) {
+	if !property.isFunction() {
+		return property, true
+	}
+
+	refValue := property.AsMap()["Fn::If"].AsList()
+
+	if len(refValue) != 3 {
+		return abortIntrinsic(property, "Fn::If should have exactly 3 values, returning original Property")
+	}
+
+	condition, _ := refValue[0].resolveValue()
+	trueState, _ := refValue[1].resolveValue()
+	falseState, _ := refValue[2].resolveValue()
+
+	conditionMet := false
+
+	con, _ := condition.resolveValue()
+	if con.IsBool() {
+		conditionMet = con.AsBool()
+	} else if property.ctx.Conditions != nil &&
+		condition.IsString() {
+
+		condition := property.ctx.Conditions[condition.AsString()]
+		if condition.isFunction() {
+			con, _ := condition.resolveValue()
+			if con.IsBool() {
+				conditionMet = con.AsBool()
+			}
+		}
+	}
+
+	if conditionMet {
+		return trueState, true
+	} else {
+		return falseState, true
+	}
+}

--- a/pkg/scanners/cloudformation/parser/fn_if_test.go
+++ b/pkg/scanners/cloudformation/parser/fn_if_test.go
@@ -1,0 +1,56 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_resolve_if_value(t *testing.T) {
+
+	property := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::If": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.Bool,
+									Value: true,
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(property)
+	require.True(t, success)
+
+	assert.Equal(t, "foo", resolvedProperty.String())
+}

--- a/pkg/scanners/cloudformation/parser/fn_not.go
+++ b/pkg/scanners/cloudformation/parser/fn_not.go
@@ -1,0 +1,23 @@
+package parser
+
+import "github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+func ResolveNot(property *Property) (resolved *Property, success bool) {
+	if !property.isFunction() {
+		return property, true
+	}
+
+	refValue := property.AsMap()["Fn::Not"].AsList()
+
+	if len(refValue) != 1 {
+		return abortIntrinsic(property, "Fn::No should have at only 1 values, returning original Property")
+	}
+
+	funcToInvert, _ := refValue[0].resolveValue()
+
+	if funcToInvert.IsBool() {
+		return property.deriveResolved(cftypes.Bool, !funcToInvert.AsBool()), true
+	}
+
+	return property, false
+}

--- a/pkg/scanners/cloudformation/parser/fn_not_test.go
+++ b/pkg/scanners/cloudformation/parser/fn_not_test.go
@@ -1,0 +1,124 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_resolve_not_value(t *testing.T) {
+	property1 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	notProperty := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Not": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							property1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(notProperty)
+	require.True(t, success)
+
+	assert.True(t, resolvedProperty.IsTrue())
+}
+
+func Test_resolve_not_value_when_true(t *testing.T) {
+	property1 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	notProperty := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Not": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							property1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(notProperty)
+	require.True(t, success)
+
+	assert.False(t, resolvedProperty.IsTrue())
+}

--- a/pkg/scanners/cloudformation/parser/fn_or.go
+++ b/pkg/scanners/cloudformation/parser/fn_or.go
@@ -1,0 +1,39 @@
+package parser
+
+import "github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+func ResolveOr(property *Property) (resolved *Property, success bool) {
+	if !property.isFunction() {
+		return property, true
+	}
+
+	refValue := property.AsMap()["Fn::Or"].AsList()
+
+	if len(refValue) < 2 {
+		return abortIntrinsic(property, "Fn::Or should have at least 2 values, returning original Property")
+	}
+
+	results := make([]bool, len(refValue))
+	for i := 0; i < len(refValue); i++ {
+
+		r := false
+		if refValue[i].IsBool() {
+			r = refValue[i].AsBool()
+		}
+
+		results[i] = r
+	}
+
+	atleastOne := atleastOne(results)
+	return property.deriveResolved(cftypes.Bool, atleastOne), true
+}
+
+func atleastOne(a []bool) bool {
+	for _, b := range a {
+		if b {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/scanners/cloudformation/parser/fn_or_test.go
+++ b/pkg/scanners/cloudformation/parser/fn_or_test.go
@@ -1,0 +1,184 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_resolve_or_value(t *testing.T) {
+	property1 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	property2 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	orProperty := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Or": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							property1,
+							property2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(orProperty)
+	require.True(t, success)
+
+	assert.True(t, resolvedProperty.IsTrue())
+}
+
+func Test_resolve_or_value_when_neither_true(t *testing.T) {
+	property1 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	property2 := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Equals": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "bar",
+								},
+							},
+							{
+								Inner: PropertyInner{
+									Type:  cftypes.String,
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	orProperty := &Property{
+		ctx:  &FileContext{},
+		name: "BucketName",
+		rng:  types.NewRange("testfile", 1, 1, "", nil),
+		Inner: PropertyInner{
+			Type: cftypes.Map,
+			Value: map[string]*Property{
+				"Fn::Or": {
+					Inner: PropertyInner{
+						Type: cftypes.List,
+						Value: []*Property{
+							property1,
+							property2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resolvedProperty, success := ResolveIntrinsicFunc(orProperty)
+	require.True(t, success)
+
+	assert.False(t, resolvedProperty.IsTrue())
+}

--- a/pkg/scanners/cloudformation/parser/intrinsics.go
+++ b/pkg/scanners/cloudformation/parser/intrinsics.go
@@ -23,7 +23,10 @@ func init() {
 		"Fn::GetAZs":      GetAzs,
 		"Fn::Cidr":        GetCidr,
 		"Fn::ImportValue": ImportPlaceholder,
-		// "Fn::If":        PassthroughResolution,
+		"Fn::If":          ResolveIf,
+		"Fn::And":         ResolveAnd,
+		"Fn::Or":          ResolveOr,
+		"Fn::Not":         ResolveNot,
 	}
 }
 

--- a/pkg/scanners/cloudformation/parser/parser.go
+++ b/pkg/scanners/cloudformation/parser/parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -85,7 +84,7 @@ func (p *Parser) Required(fs fs.FS, path string) bool {
 		return false
 	}
 	defer func() { _ = f.Close() }()
-	if data, err := ioutil.ReadAll(f); err == nil {
+	if data, err := io.ReadAll(f); err == nil {
 		return detection.IsType(path, bytes.NewReader(data), detection.FileTypeCloudFormation)
 	}
 	return false
@@ -117,7 +116,7 @@ func (p *Parser) ParseFile(ctx context.Context, fs fs.FS, path string) (context 
 	}
 	defer func() { _ = f.Close() }()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanners/cloudformation/parser/property.go
+++ b/pkg/scanners/cloudformation/parser/property.go
@@ -146,6 +146,7 @@ func (p *Property) RawValue() interface{} {
 }
 
 func (p *Property) AsRawStrings() ([]string, error) {
+
 	if len(p.ctx.lines) < p.rng.GetEndLine() {
 		return p.ctx.lines, nil
 	}
@@ -266,7 +267,7 @@ func (p *Property) GetProperty(path string) *Property {
 		}
 	}
 
-	return nil
+	return &Property{}
 }
 
 func (p *Property) deriveResolved(propType cftypes.CfType, propValue interface{}) *Property {
@@ -358,6 +359,9 @@ func (p *Property) SetLogicalResource(id string) {
 }
 
 func (p *Property) GetJsonBytes(squashList ...bool) []byte {
+	if p.IsNil() {
+		return []byte{}
+	}
 	lines, err := p.AsRawStrings()
 	if err != nil {
 		return nil

--- a/pkg/scanners/cloudformation/parser/pseudo_parameters.go
+++ b/pkg/scanners/cloudformation/parser/pseudo_parameters.go
@@ -3,7 +3,7 @@ package parser
 var pseudoParameters = map[string]interface{}{
 	"AWS::AccountId":        "123456789012",
 	"AWS::NotificationARNs": []string{"notification::arn::1", "notification::arn::2"},
-	"AWS::NoValue":          "",
+	"AWS::NoValue":          nil,
 	"AWS::Partition":        "aws",
 	"AWS::Region":           "eu-west-1",
 	"AWS::StackId":          "arn:aws:cloudformation:eu-west-1:stack/ID",

--- a/pkg/scanners/cloudformation/test/examples/roles/roles.yml
+++ b/pkg/scanners/cloudformation/test/examples/roles/roles.yml
@@ -1,0 +1,51 @@
+Resources:
+  LambdaAPIRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: "${self:service}-${self:provider.stage}-LambdaAPI"
+      Policies:
+        - PolicyName: "${self:service}-${self:provider.stage}-lambda"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:CreateLogGroup"
+                  - "logs:PutLogEvents"
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:service}-${self:provider.stage}*:*"
+        - !If
+          - EnableCrossAccountSnsPublish
+          - PolicyName: "${self:service}-${self:provider.stage}-asngen-sns-publish"
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - "SNS:Publish"
+                  Resource:
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-PurchaseOrder.fifo"
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-Vendor.fifo"
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-Customer.fifo"
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-Manufacturer.fifo"
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-ManufacturerItem.fifo"
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-Item.fifo"
+                    - !Sub "arn:aws:sns:${self:provider.region}:${self:provider.itopia_account_id}:${self:provider.stage}-*-VendorItem.fifo"
+          - !Ref "AWS::NoValue"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+
+
+
+
+Conditions:
+  EnableCrossAccountSnsPublish: !Equals
+    - ${env:ALLOW_SNS_PUBLISH, true}
+    - true

--- a/pkg/scanners/helm/parser/parser.go
+++ b/pkg/scanners/helm/parser/parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -182,7 +181,7 @@ func (p *Parser) extractChartName(chartPath string) error {
 
 func (p *Parser) RenderedChartFiles() ([]ChartFile, error) {
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "defsec")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "defsec")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanners/helm/parser/vals.go
+++ b/pkg/scanners/helm/parser/vals.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -93,7 +93,7 @@ func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
 // readFile load a file from stdin, the local directory, or a remote file with a url.
 func readFile(filePath string) ([]byte, error) {
 	if strings.TrimSpace(filePath) == "-" {
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	}
 	u, _ := url.Parse(filePath)
 
@@ -109,6 +109,6 @@ func readFile(filePath string) ([]byte, error) {
 		}
 		return data.Bytes(), err
 	} else {
-		return ioutil.ReadFile(filePath)
+		return os.ReadFile(filePath)
 	}
 }

--- a/pkg/scanners/kubernetes/parser/parser.go
+++ b/pkg/scanners/kubernetes/parser/parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -92,7 +91,7 @@ func (p *Parser) required(fs fs.FS, path string) bool {
 		return false
 	}
 	defer func() { _ = f.Close() }()
-	if data, err := ioutil.ReadAll(f); err == nil {
+	if data, err := io.ReadAll(f); err == nil {
 		return detection.IsType(path, bytes.NewReader(data), detection.FileTypeKubernetes)
 	}
 	return false
@@ -100,7 +99,7 @@ func (p *Parser) required(fs fs.FS, path string) bool {
 
 func (p *Parser) Parse(r io.Reader, path string) ([]interface{}, error) {
 
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanners/kubernetes/scanner.go
+++ b/pkg/scanners/kubernetes/scanner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"sync"
 
@@ -118,7 +117,7 @@ func (s *Scanner) ScanReader(ctx context.Context, filename string, reader io.Rea
 	if err := memfs.MkdirAll(filepath.Base(filename), 0o700); err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanners/rbac/parser/parser.go
+++ b/pkg/scanners/rbac/parser/parser.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/aquasecurity/defsec/pkg/debug"
@@ -79,7 +78,7 @@ func (p *Parser) required(fs fs.FS, path string) bool {
 		return false
 	}
 	defer func() { _ = f.Close() }()
-	if data, err := ioutil.ReadAll(f); err == nil {
+	if data, err := io.ReadAll(f); err == nil {
 		return detection.IsType(path, bytes.NewReader(data), detection.FileTypeRbac)
 	}
 	return false

--- a/pkg/scanners/rbac/scanner.go
+++ b/pkg/scanners/rbac/scanner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"sync"
 
@@ -149,7 +148,7 @@ func (s *Scanner) ScanReader(ctx context.Context, filename string, reader io.Rea
 	if err := memfs.MkdirAll(filepath.Base(filename), 0o700); err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanners/terraform/parser/funcs/collection.go
+++ b/pkg/scanners/terraform/parser/funcs/collection.go
@@ -668,7 +668,8 @@ func Index(list, value cty.Value) (cty.Value, error) {
 }
 
 // List takes any number of list arguments and returns a list containing those
-//  values in the same order.
+//
+//	values in the same order.
 func List(args ...cty.Value) (cty.Value, error) {
 	return ListFunc.Call(args)
 }

--- a/pkg/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/scanners/terraform/parser/funcs/filesystem.go
@@ -4,8 +4,8 @@ package funcs
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"unicode/utf8"
@@ -13,7 +13,7 @@ import (
 	"github.com/bmatcuk/doublestar"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -383,7 +383,7 @@ func readFileBytes(target fs.FS, baseDir, path string) ([]byte, error) {
 		return nil, err
 	}
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s", path)
 	}

--- a/pkg/scanners/terraform/parser/parser.go
+++ b/pkg/scanners/terraform/parser/parser.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -153,7 +152,7 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/scanners/yaml/parser/parser.go
+++ b/pkg/scanners/yaml/parser/parser.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -79,7 +78,7 @@ func (p *Parser) ParseFile(_ context.Context, fs fs.FS, path string) ([]interfac
 	}
 	defer func() { _ = f.Close() }()
 
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/test/docker_test.go
+++ b/test/docker_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -131,7 +130,7 @@ func addFilesToMemFS(memfs *memoryfs.FS, typePolicy bool, folderName string) err
 			if strings.Contains(fpath, filepath.FromSlash("/lib/")) {
 				return nil
 			}
-			data, err := ioutil.ReadFile(fpath)
+			data, err := os.ReadFile(fpath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #962 

includes a bit of housekeeping switching away from the now deprecated `ioutil` calls

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
