### PR TITLE
fix: return empty array with no warnings in --format json

### DIFF
--- a/pkg/formatters/json.go
+++ b/pkg/formatters/json.go
@@ -9,7 +9,7 @@ import (
 func outputJSON(b ConfigurableFormatter, results scan.Results) error {
 	jsonWriter := json.NewEncoder(b.Writer())
 	jsonWriter.SetIndent("", "\t")
-	var flatResults []scan.FlatResult
+	var flatResults = []scan.FlatResult{}
 	for _, result := range results {
 		switch result.Status() {
 		case scan.StatusIgnored:

--- a/pkg/formatters/json_test.go
+++ b/pkg/formatters/json_test.go
@@ -70,3 +70,15 @@ func Test_JSON(t *testing.T) {
 	require.NoError(t, formatter.Output(results))
 	assert.Equal(t, want, buffer.String())
 }
+
+func Test_JSONWithEmptyResults(t *testing.T) {
+	want := `{
+	"results": []
+}
+`
+	buffer := bytes.NewBuffer([]byte{})
+	formatter := New().AsJSON().WithWriter(buffer).Build()
+	var results scan.Results
+	require.NoError(t, formatter.Output(results))
+	assert.Equal(t, want, buffer.String())
+}


### PR DESCRIPTION
While developing a vim plugin, I noticed that when I run `tfsec` with the `--format json` option, if there is no lint error, it returns the following response.

```json
{ "results": null }
```

Although `null` is valid value in the JSON schema, it seems more appropriate to return an empty array so that we can handle the output more easily.

## changes

* use empty array instead of null when there's no warnings
* add test to check JSON formatter handles empty results