### PR TITLE
feat: Port cloudsploit rule 'RDS Deletion Protection Enabled' to rego

### DIFF
--- a/avd_docs/aws/rds/AVD-AWS-0177/docs.md
+++ b/avd_docs/aws/rds/AVD-AWS-0177/docs.md
@@ -1,0 +1,13 @@
+
+Ensure deletion protection is enabled for RDS database instances.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://aws.amazon.com/about-aws/whats-new/2018/09/amazon-rds-now-provides-database-deletion-protection/
+
+

--- a/internal/adapters/cloud/aws/rds/rds.go
+++ b/internal/adapters/cloud/aws/rds/rds.go
@@ -145,10 +145,11 @@ func (a *adapter) adaptDBInstance(dbInstance types.DBInstance) (*rds.Instance, e
 			dbInstance.PerformanceInsightsKMSKeyId,
 			dbInstanceMetadata,
 		),
-		Encryption:     getInstanceEncryption(dbInstance.StorageEncrypted, dbInstance.KmsKeyId, dbInstanceMetadata),
-		PublicAccess:   defsecTypes.Bool(dbInstance.PubliclyAccessible, dbInstanceMetadata),
-		Engine:         defsecTypes.String(engine, dbInstanceMetadata),
-		IAMAuthEnabled: defsecTypes.Bool(dbInstance.IAMDatabaseAuthenticationEnabled, dbInstanceMetadata),
+		Encryption:         getInstanceEncryption(dbInstance.StorageEncrypted, dbInstance.KmsKeyId, dbInstanceMetadata),
+		PublicAccess:       defsecTypes.Bool(dbInstance.PubliclyAccessible, dbInstanceMetadata),
+		Engine:             defsecTypes.String(engine, dbInstanceMetadata),
+		IAMAuthEnabled:     defsecTypes.Bool(dbInstance.IAMDatabaseAuthenticationEnabled, dbInstanceMetadata),
+		DeletionProtection: defsecTypes.Bool(dbInstance.DeletionProtection, dbInstanceMetadata),
 	}
 
 	return instance, nil

--- a/internal/adapters/cloudformation/aws/rds/instance.go
+++ b/internal/adapters/cloudformation/aws/rds/instance.go
@@ -25,9 +25,10 @@ func getClustersAndInstances(ctx parser.FileContext) (clusters []rds.Cluster, or
 				EncryptStorage: r.GetBoolProperty("StorageEncrypted"),
 				KMSKeyID:       r.GetStringProperty("KmsKeyId"),
 			},
-			PublicAccess:   r.GetBoolProperty("PubliclyAccessible", true),
-			Engine:         r.GetStringProperty("Engine"),
-			IAMAuthEnabled: r.GetBoolProperty("EnableIAMDatabaseAuthentication"),
+			PublicAccess:       r.GetBoolProperty("PubliclyAccessible", true),
+			Engine:             r.GetStringProperty("Engine"),
+			IAMAuthEnabled:     r.GetBoolProperty("EnableIAMDatabaseAuthentication"),
+			DeletionProtection: r.GetBoolProperty("DeletionProtection", false),
 		}
 
 		if clusterID := r.GetProperty("DBClusterIdentifier"); clusterID.IsString() {

--- a/internal/adapters/terraform/aws/rds/adapt.go
+++ b/internal/adapters/terraform/aws/rds/adapt.go
@@ -112,6 +112,7 @@ func adaptInstance(resource *terraform.Block, modules terraform.Modules) rds.Ins
 		PublicAccess:              resource.GetAttribute("publicly_accessible").AsBoolValueOrDefault(false, resource),
 		Engine:                    resource.GetAttribute("engine").AsStringValueOrDefault(rds.EngineAurora, resource),
 		IAMAuthEnabled:            resource.GetAttribute("iam_database_authentication_enabled").AsBoolValueOrDefault(false, resource),
+		DeletionProtection:        resource.GetAttribute("deletion_protection").AsBoolValueOrDefault(false, resource),
 	}
 }
 

--- a/internal/rules/policies/cloud/policies/aws/rds/enable_deletion_protection.rego
+++ b/internal/rules/policies/cloud/policies/aws/rds/enable_deletion_protection.rego
@@ -1,0 +1,25 @@
+# METADATA
+# title: "RDS Deletion Protection Disabled"
+# description: "Ensure deletion protection is enabled for RDS database instances."
+# scope: package
+# schemas:
+# - input: schema.input
+# related_resources:
+# - https://aws.amazon.com/about-aws/whats-new/2018/09/amazon-rds-now-provides-database-deletion-protection/
+# custom:
+#   avd_id: AVD-AWS-0177
+#   provider: aws
+#   service: rds
+#   severity: MEDIUM
+#   short_code: enable-deletion-protection
+#   recommended_action: "Modify the RDS instances to enable deletion protection."
+#   input:
+#     selector:
+#     - type: cloud
+package builtin.aws.rds.aws0177
+
+deny[res] {
+	instance := input.aws.rds.instances[_]
+	not instance.deletionprotection.value
+	res := result.new("Instance does not have Deletion Protection enabled", instance.deletionprotection)
+}

--- a/internal/rules/policies/cloud/policies/aws/rds/enable_deletion_protection_test.rego
+++ b/internal/rules/policies/cloud/policies/aws/rds/enable_deletion_protection_test.rego
@@ -1,16 +1,11 @@
 package builtin.aws.rds.aws0177
 
 test_detects_when_disabled {
-	r := deny with input as {"aws": {"rds": {"instances": [{
-		"deletionprotection": {"value": false},
-	}]}}}
+	r := deny with input as {"aws": {"rds": {"instances": [{"deletionprotection": {"value": false}}]}}}
 	count(r) == 1
 }
 
 test_when_enabled {
-	r := deny with input as {"aws": {"rds": {"instances": [{
-		"deletionprotection": {"value": true},
-	}]}}}
+	r := deny with input as {"aws": {"rds": {"instances": [{"deletionprotection": {"value": true}}]}}}
 	count(r) == 0
 }
-

--- a/internal/rules/policies/cloud/policies/aws/rds/enable_deletion_protection_test.rego
+++ b/internal/rules/policies/cloud/policies/aws/rds/enable_deletion_protection_test.rego
@@ -1,0 +1,16 @@
+package builtin.aws.rds.aws0177
+
+test_detects_when_disabled {
+	r := deny with input as {"aws": {"rds": {"instances": [{
+		"deletionprotection": {"value": false},
+	}]}}}
+	count(r) == 1
+}
+
+test_when_enabled {
+	r := deny with input as {"aws": {"rds": {"instances": [{
+		"deletionprotection": {"value": true},
+	}]}}}
+	count(r) == 0
+}
+

--- a/pkg/providers/aws/rds/rds.go
+++ b/pkg/providers/aws/rds/rds.go
@@ -57,6 +57,7 @@ type Instance struct {
 	PublicAccess              defsecTypes.BoolValue
 	Engine                    defsecTypes.StringValue
 	IAMAuthEnabled            defsecTypes.BoolValue
+	DeletionProtection        defsecTypes.BoolValue
 }
 
 type ClusterInstance struct {

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -2364,6 +2364,10 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.IntValue"
         },
+        "deletionprotection": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.BoolValue"
+        },
         "encryption": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.rds.Encryption"


### PR DESCRIPTION
This ports the check from https://github.com/aquasecurity/cloudsploit/blob/master/plugins/aws/rds/rdsDeletionProtectionEnabled.js