### PR TITLE
fix: wrong lines in multi manifest k8s files

### DIFF
--- a/pkg/rego/result.go
+++ b/pkg/rego/result.go
@@ -106,6 +106,19 @@ func parseLineNumber(raw interface{}) int {
 
 func (s *Scanner) convertResults(set rego.ResultSet, input Input, namespace string, rule string, traces []string) scan.Results {
 	var results scan.Results
+
+	offset := 0
+	if input.Contents != nil {
+		if xx, ok := input.Contents.(map[string]interface{}); ok {
+			if md, ok := xx["__defsec_metadata"]; ok {
+				if md2, ok := md.(map[string]interface{}); ok {
+					if sl, ok := md2["offset"]; ok {
+						offset, _ = sl.(int)
+					}
+				}
+			}
+		}
+	}
 	for _, result := range set {
 		for _, expression := range result.Expressions {
 			values, ok := expression.Value.([]interface{})
@@ -118,6 +131,8 @@ func (s *Scanner) convertResults(set rego.ResultSet, input Input, namespace stri
 				if regoResult.Message == "" {
 					regoResult.Message = fmt.Sprintf("Rego policy rule: %s.%s", namespace, rule)
 				}
+				regoResult.StartLine += offset
+				regoResult.EndLine += offset
 				results.AddRego(regoResult.Message, namespace, rule, traces, regoResult)
 				continue
 			}
@@ -131,6 +146,8 @@ func (s *Scanner) convertResults(set rego.ResultSet, input Input, namespace stri
 				if regoResult.Message == "" {
 					regoResult.Message = fmt.Sprintf("Rego policy rule: %s.%s", namespace, rule)
 				}
+				regoResult.StartLine += offset
+				regoResult.EndLine += offset
 				results.AddRego(regoResult.Message, namespace, rule, traces, regoResult)
 			}
 		}

--- a/pkg/scanners/kubernetes/parser/manifest_node.go
+++ b/pkg/scanners/kubernetes/parser/manifest_node.go
@@ -22,6 +22,7 @@ const (
 type ManifestNode struct {
 	StartLine int
 	EndLine   int
+	Offset    int
 	Value     interface{}
 	Type      TagType
 	Path      string
@@ -46,6 +47,7 @@ func (r *ManifestNode) ToRego() interface{} {
 			"startline": r.StartLine,
 			"endline":   r.EndLine,
 			"filepath":  r.Path,
+			"offset":    r.Offset,
 		}
 		for key, node := range r.Value.(map[string]ManifestNode) {
 			output[key] = node.ToRego()

--- a/pkg/scanners/rbac/scanner_test.go
+++ b/pkg/scanners/rbac/scanner_test.go
@@ -299,8 +299,8 @@ rules:
 	assert.Greater(t, len(results.GetFailed()), 0)
 
 	firstResult := results.GetFailed()[0]
-	assert.Equal(t, 2, firstResult.Metadata().Range().GetStartLine())
-	assert.Equal(t, 2, firstResult.Metadata().Range().GetEndLine())
+	assert.Equal(t, 4, firstResult.Metadata().Range().GetStartLine())
+	assert.Equal(t, 4, firstResult.Metadata().Range().GetEndLine())
 	assert.Equal(t, "chartname/template/serviceAccount.yaml", firstResult.Metadata().Range().GetFilename())
 }
 


### PR DESCRIPTION
This pr fixes a mismatch in the lines when a k8s multi manifest file is parsed.
See https://github.com/aquasecurity/trivy/issues/2965