### PR TITLE
Migrating the rules from Aqua commercial/Kube Enforcer into defsec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners and reviewers for everything in
 # the repo. 
-*       @liamg @owenrumney
+*       @liamg @owenrumney @simar7

--- a/avd_docs/kubernetes/general/AVD-KSV-01010/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-01010/docs.md
@@ -1,0 +1,10 @@
+
+Storing sensitive content such as usernames and email addresses in configMaps is unsafe
+
+### Impact
+Unsafe storage of sensitive content in configMaps could lead to the information being compromised.
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+

--- a/avd_docs/kubernetes/general/AVD-KSV-0108/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-0108/docs.md
@@ -1,0 +1,10 @@
+
+Services with external IP addresses allows direct access from the internet and might expose risk for CVE-2020-8554
+
+### Impact
+Kubernetes API server in all versions allow an attacker who is able to create a ClusterIP service and set the spec.externalIPs field, to intercept traffic to that IP address. Additionally, an attacker who is able to patch the status (which is considered a privileged operation and should not typically be granted to users) of a LoadBalancer service can set the status.loadBalancer.ingress.ip to similar effect.
+https://www.cvedetails.com/cve/CVE-2020-8554/
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+

--- a/avd_docs/kubernetes/general/AVD-KSV-0109/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-0109/docs.md
@@ -1,0 +1,10 @@
+
+Storing secrets in configMaps is unsafe
+
+### Impact
+Unsafe storage of secret content in configMaps could lead to the information being compromised.
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+

--- a/internal/rules/policies/kubernetes/policies/aquacommercial/configMap_with_secrets.rego
+++ b/internal/rules/policies/kubernetes/policies/aquacommercial/configMap_with_secrets.rego
@@ -1,0 +1,96 @@
+# METADATA
+# title: "ConfigMap with secrets"
+# description: "Storing secrets in configMaps is unsafe"
+# scope: package
+# schemas:
+# - input: schema["input"]
+# custom:
+#   id: AVD-KSV-0109
+#   avd_id: AVD-KSV-0109
+#   severity: HIGH
+#   short_code: configMap_with_secrets
+#   recommended_action: "Remove password/secret from configMap data value"
+#   input:
+#     selector:
+#     - type: kubernetes
+
+package builtin.kubernetes.KSV0109
+
+import data.lib.kubernetes
+
+# More patterns can be added here, adding more patterns may lead to performance issue
+patterns := [
+	"(?i)(password\\s*(=|:))",
+	"(?i)(pw\\s*(=|:))",
+	"(?i)(pass\\s*(=|:))",
+	"(?i)(pword\\s*(=|:))",
+	"(?i)(passphrase\\s*(=|:))",
+	"(?i)(passwrd\\s*(=|:))",
+	"(?i)(passwd\\s*(=|:))",
+	"(?i)(secret\\s*(=|:))",
+	"(?i)(secretkey\\s*(=|:))",
+	"(?i)(appSecret\\s*(=|:))",
+	"(?i)(clientSecret\\s*(=|:))",
+	"(?i)(aws_access_key_id\\s*(=|:))",
+	"(?i)(pswrd\\s*(=|:))",
+	"(?i)(token\\s*(=|:))",
+	"(?i)(pwd\\s*(=|:))",
+]
+
+#Added patterns for detecting secrets in key
+patternsForKey := [
+	"(?i)(password\\s*)",
+	"(?i)(pw\\s*)",
+	"(?i)(pass\\s*)",
+	"(?i)(pword\\s*)",
+	"(?i)(passphrase\\s*)",
+	"(?i)(passwrd\\s*)",
+	"(?i)(passwd\\s*)",
+	"(?i)(secret\\s*)",
+	"(?i)(secretkey\\s*)",
+	"(?i)(appSecret\\s*)",
+	"(?i)(clientSecret\\s*)",
+	"(?i)(aws_access_key_id\\s*)",
+	"(?i)(pswrd\\s*)",
+	"(?i)(token\\s*)",
+	"(?i)(pwd\\s*)",
+]
+
+# ConfigMapWithSecret gives secret key
+# To reduce performace overhead, only matched patterns will be applied to each value for key
+ConfigMapWithSecret[secrets] {
+	kubernetes.kind == "ConfigMap"
+	regex.match(patterns[p], kubernetes.object.data[d])
+
+	values := split(kubernetes.object.data[d], "\n")
+	regex.match(patterns[p], values[v])
+	secrets = configMapValue(values[v])
+}
+
+# configMapValue gives secret key, splitting either by '=' or ':'
+configMapValue(value) = secretValue {
+	secrets := split(value, ":")
+	count(secrets) > 1
+	secretValue = secrets[0]
+} else = secretValue {
+	secrets := split(value, "=")
+	count(secrets) > 1
+	secretValue = secrets[0]
+}
+
+#check if key has secrets
+ConfigMapWithSecret[secrets] {
+	kubernetes.kind == "ConfigMap"
+	values = split(kubernetes.object.data[d], "\n")
+	regex.match(patternsForKey[p], d)
+	secrets = d
+}
+
+# Get the secret list, 'configMapSecretList' will be reused in rule deny to avoid multiple call for pattern search
+configMapSecretList := ConfigMapWithSecret
+
+deny[res] {
+	count(configMapSecretList) > 0
+	msg := kubernetes.format(sprintf("%s '%s' in '%s' namespace stores secrets in key(s) or value(s) '%s'", [kubernetes.kind, kubernetes.name, kubernetes.namespace, configMapSecretList]))
+	res := result.new(msg, kubernetes.kind)
+}

--- a/internal/rules/policies/kubernetes/policies/aquacommercial/configMap_with_secrets_test.rego
+++ b/internal/rules/policies/kubernetes/policies/aquacommercial/configMap_with_secrets_test.rego
@@ -1,0 +1,30 @@
+package builtin.kubernetes.KSV0109
+
+test_configMap_with_secrets_denied {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "cm-with-secrets"},
+		"data": {
+			"password": "password123",
+			"secretkey": "test",
+		},
+	}
+
+	count(r) == 1
+	r[_].msg == "ConfigMap 'cm-with-secrets' in 'default' namespace stores secrets in key(s) or value(s) '{\"password\", \"secretkey\"}'"
+}
+
+test_configMap_with_secrets_allowed {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "cm-with-secrets"},
+		"data": {
+			"color.good": "blue",
+			"color.bad": "yellow",
+		},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/policies/kubernetes/policies/aquacommercial/configMap_with_sensitive_test.rego
+++ b/internal/rules/policies/kubernetes/policies/aquacommercial/configMap_with_sensitive_test.rego
@@ -1,0 +1,31 @@
+package builtin.kubernetes.KSV01010
+
+test_configMap_with_sensitive_denied {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "cm-with-sensitive"},
+		"data": {
+			"color.good": "blue",
+			"color.bad": "yellow",
+			"username": "test",
+		},
+	}
+
+	count(r) == 1
+	r[_].msg == "ConfigMap 'cm-with-sensitive' in 'default' namespace stores sensitive contents in key(s) or value(s) '{\"username\"}'"
+}
+
+test_configMap_with_sensitive_allowed {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {"name": "cm-with-sensitive"},
+		"data": {
+			"color.good": "blue",
+			"color.bad": "yellow",
+		},
+	}
+
+	count(r) == 0
+}

--- a/internal/rules/policies/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego
+++ b/internal/rules/policies/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego
@@ -1,0 +1,91 @@
+# METADATA
+# title: "ConfigMap with sensitive content"
+# description: "Storing sensitive content such as usernames and email addresses in configMaps is unsafe"
+# scope: package
+# schemas:
+# - input: schema["input"]
+# custom:
+#   id: AVD-KSV-0110
+#   avd_id: AVD-KSV-01010
+#   severity: HIGH
+#   short_code: configMap_with_sensitive
+#   recommended_action: "Remove sensitive content from configMap data value"
+#   input:
+#     selector:
+#     - type: kubernetes
+
+package builtin.kubernetes.KSV01010
+
+import data.lib.kubernetes
+
+# More patterns can be added here, adding more patterns may lead to performance issue
+# some patterns are taken from https://github.com/americanexpress/earlybird/blob/d0b63538c1acbb5ab0cacf0541df5ea088d45d70/config/content.json
+patterns := [
+	"(?i)(username\\s*(=|:))",
+	"(?i)(email\\s*(=|:))",
+	"([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)",
+	"(?i)(key\\s*(=|:))",
+	"(?i)(phone\\s*(=|:))",
+	"[^\\.](?:\\b[A-Z]{2}\\d{2} ?\\d{4} ?\\d{4} ?\\d{4} ?\\d{4} ?[\\d]{0,2}\\b)",
+	"(?i)(SHA1)",
+	"(?i)(MD5)",
+]
+
+patternsForKey := [
+	"(?i)(username\\s*)",
+	"(?i)(email\\s*)",
+	"([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)",
+	"(?i)(key\\s*)",
+	"(?i)(phone\\s*)",
+	"[^\\.](?:\\b[A-Z]{2}\\d{2} ?\\d{4} ?\\d{4} ?\\d{4} ?\\d{4} ?[\\d]{0,2}\\b)",
+	"(?i)(SHA1\\s*)",
+	"(?i)(MD5\\s*)",
+]
+
+patternsForEmail := "([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)"
+
+# ConfigMapWithSensitive gives secret key
+# To reduce performance overhead, only matched patterns will be applied to each value for key
+ConfigMapWithSensitive[sensitiveData] {
+	kubernetes.kind == "ConfigMap"
+	regex.match(patterns[p], kubernetes.object.data[d])
+
+	values := split(kubernetes.object.data[d], "\n")
+	regex.match(patterns[p], values[v])
+	sensitiveData = configMapValue(values[v])
+}
+
+# configMapValue gives sensitive key, splitting either by '=' or ':'
+configMapValue(value) = sensitiveValue {
+	sensitiveData := split(value, ":")
+	count(sensitiveData) > 1
+	sensitiveValue = sensitiveData[0]
+} else = sensitiveValue {
+	sensitiveData := split(value, "=")
+	count(sensitiveData) > 1
+	sensitiveValue = sensitiveData[0]
+}
+
+#check if key has sensitive data
+ConfigMapWithSensitive[sensitiveData] {
+	kubernetes.kind == "ConfigMap"
+	values = split(kubernetes.object.data[d], "\n")
+	regex.match(patternsForKey[p], d)
+	sensitiveData = d
+}
+
+ConfigMapWithSensitive[sensitiveData] {
+	kubernetes.kind == "ConfigMap"
+	values = split(kubernetes.object.data[d], "\n")
+	val = split(values[v], ":")
+	regex.match(patternsForEmail, val[v])
+	sensitiveData = d
+}
+
+configMapSensitiveList := ConfigMapWithSensitive
+
+deny[res] {
+	count(configMapSensitiveList) > 0
+	msg := kubernetes.format(sprintf("%s '%s' in '%s' namespace stores sensitive contents in key(s) or value(s) '%s'", [kubernetes.kind, kubernetes.name, kubernetes.namespace, configMapSensitiveList]))
+	res := result.new(msg, kubernetes.kind)
+}

--- a/internal/rules/policies/kubernetes/policies/aquacommercial/service_with_externalip.rego
+++ b/internal/rules/policies/kubernetes/policies/aquacommercial/service_with_externalip.rego
@@ -1,0 +1,42 @@
+# METADATA
+# title: "Service with External IP"
+# description: "Services with external IP addresses allows direct access from the internet and might expose risk for CVE-2020-8554"
+# scope: package
+# schemas:
+# - input: schema["input"]
+# custom:
+#   id: AVD-KSV-0108
+#   avd_id: AVD-KSV-0108
+#   severity: HIGH
+#   short_code: no_svc_with_extip
+#   recommended_action: "Do not set spec.externalIPs"
+#   input:
+#     selector:
+#     - type: kubernetes
+package builtin.kubernetes.KSV0108
+
+import data.lib.kubernetes
+
+allowedIPs = set()
+
+allowedNames = set()
+
+# failExtIpsOrName is true if service has external IPs
+failExtIpsOrName {
+	kubernetes.kind == "Service"
+	externalIPs := {ip | ip := kubernetes.object.spec.externalIPs[_]}
+	forbiddenIPs := externalIPs - allowedIPs
+	count(forbiddenIPs) > 0
+}
+
+# failExtIpsOrName is true if service has external Name
+failExtIpsOrName {
+	kubernetes.kind == "Service"
+	not allowedNames[kubernetes.object.spec.externalName]
+}
+
+deny[res] {
+	failExtIpsOrName
+	msg := kubernetes.format(sprintf("%s '%s' in '%s' namespace should not set external IPs or external Name", [kubernetes.kind, kubernetes.name, kubernetes.namespace]))
+	res := result.new(msg, kubernetes.kind)
+}

--- a/internal/rules/policies/kubernetes/policies/aquacommercial/service_with_externalip_test.rego
+++ b/internal/rules/policies/kubernetes/policies/aquacommercial/service_with_externalip_test.rego
@@ -1,0 +1,41 @@
+package builtin.kubernetes.KSV0108
+
+test_service_with_externalip_denied {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {"name": "service_with_externalip"},
+		"spec": {
+			"ports": [{
+				"name": "http",
+				"port": 80,
+				"protocol": "TCP",
+				"targetPort": 9376,
+			}],
+			"selector": {"app.kubernetes.io/name": "MyApp"},
+			"externalIPs": ["192.168.0.106"],
+		},
+	}
+
+	count(r) == 1
+	r[_].msg == "Service 'service_with_externalip' in 'default' namespace should not set external IPs or external Name"
+}
+
+test_service_with_externalip_allowed {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {"name": "service_with_externalip"},
+		"spec": {
+			"ports": [{
+				"name": "http",
+				"port": 80,
+				"protocol": "TCP",
+				"targetPort": 9376,
+			}],
+			"selector": {"app.kubernetes.io/name": "MyApp"},
+		},
+	}
+
+	count(r) == 0
+}


### PR DESCRIPTION
Few rules which are present in Aqua product (which is used by Kube-enforcer) is not present in defsec. Migrating few policies to aquacommercial folder