### PR TITLE
Compatible with Go 1.18

### DIFF
--- a/pkg/scanners/azure/functions/uri.go
+++ b/pkg/scanners/azure/functions/uri.go
@@ -1,15 +1,29 @@
 package functions
 
-import "net/url"
+import (
+	"net/url"
+	"path"
+)
 
 func Uri(args ...interface{}) interface{} {
 	if len(args) != 2 {
 		return ""
 	}
 
-	path, err := url.JoinPath(args[0].(string), args[1].(string))
+	result, err := joinPath(args[0].(string), args[1].(string))
 	if err != nil {
 		return ""
 	}
-	return path
+	return result
+}
+
+// Backport url.JoinPath until we're ready for Go 1.19
+func joinPath(base string, elem ...string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	elem = append([]string{u.EscapedPath()}, elem...)
+	u.Path = path.Join(elem...)
+	return u.String(), nil
 }

--- a/pkg/scanners/azure/functions/uri_test.go
+++ b/pkg/scanners/azure/functions/uri_test.go
@@ -28,6 +28,14 @@ func Test_Uri(t *testing.T) {
 			},
 			expected: "http://contoso.org/firstpath/myscript.sh",
 		},
+		{
+			name: "uri from a base with trailing slash and relative with ../",
+			args: []interface{}{
+				"http://contoso.org/firstpath/",
+				"../myscript.sh",
+			},
+			expected: "http://contoso.org/myscript.sh",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Aqua internal tools need to compile Trivy/defsec with Go 1.18. We need to backport `net/url.JoinPath`, which is introduced in Go 1.19 so defsec will be compatible with Go 1.18.
https://pkg.go.dev/net/url#JoinPath