### PR TITLE
add SetInputSchema function to ConfigurableScanner

### DIFF
--- a/pkg/rego/scanner.go
+++ b/pkg/rego/scanner.go
@@ -106,6 +106,10 @@ func (s *Scanner) SetSkipRequiredCheck(_ bool) {
 	// NOTE: Skip required option not applicable for rego.
 }
 
+func (s *Scanner) SetInputSchema(schema interface{}) {
+	s.inputSchema = schema
+}
+
 type DynamicMetadata struct {
 	Warning   bool
 	Filepath  string

--- a/pkg/scanners/azure/arm/scanner.go
+++ b/pkg/scanners/azure/arm/scanner.go
@@ -92,6 +92,10 @@ func (s *Scanner) SetFrameworks(frameworks []framework.Framework) {
 	s.frameworks = frameworks
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func (s *Scanner) SetTraceWriter(io.Writer)        {}
 func (s *Scanner) SetPerResultTracingEnabled(bool) {}
 func (s *Scanner) SetDataDirs(...string)           {}

--- a/pkg/scanners/cloud/aws/scanner.go
+++ b/pkg/scanners/cloud/aws/scanner.go
@@ -89,6 +89,10 @@ func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
 	s.useEmbedded = b
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func (s *Scanner) SetTraceWriter(writer io.Writer)   {}
 func (s *Scanner) SetPerResultTracingEnabled(b bool) {}
 func (s *Scanner) SetDataDirs(s2 ...string)          {}

--- a/pkg/scanners/cloudformation/scanner.go
+++ b/pkg/scanners/cloudformation/scanner.go
@@ -82,6 +82,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func (s *Scanner) SetTraceWriter(_ io.Writer)        {}
 func (s *Scanner) SetPerResultTracingEnabled(_ bool) {}
 func (s *Scanner) SetDataDirs(_ ...string)           {}

--- a/pkg/scanners/dockerfile/scanner.go
+++ b/pkg/scanners/dockerfile/scanner.go
@@ -92,6 +92,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/helm/scanner.go
+++ b/pkg/scanners/helm/scanner.go
@@ -114,6 +114,10 @@ func (s *Scanner) SetPolicyFilesystem(policyFS fs.FS) {
 	s.policyFS = policyFS
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func (s *Scanner) ScanFS(ctx context.Context, target fs.FS, path string) (scan.Results, error) {
 
 	var results []scan.Result

--- a/pkg/scanners/json/scanner.go
+++ b/pkg/scanners/json/scanner.go
@@ -86,6 +86,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/kubernetes/scanner.go
+++ b/pkg/scanners/kubernetes/scanner.go
@@ -89,6 +89,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/options/scanner.go
+++ b/pkg/scanners/options/scanner.go
@@ -21,6 +21,7 @@ type ConfigurableScanner interface {
 	SetFrameworks(frameworks []framework.Framework)
 	SetSpec(spec string)
 	SetRegoOnly(regoOnly bool)
+	SetInputSchema(schema interface{})
 }
 
 type ScannerOption func(s ConfigurableScanner)

--- a/pkg/scanners/rbac/scanner.go
+++ b/pkg/scanners/rbac/scanner.go
@@ -78,6 +78,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -122,6 +122,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 type Metrics struct {
 	Parser   parser.Metrics
 	Executor executor.Metrics

--- a/pkg/scanners/toml/scanner.go
+++ b/pkg/scanners/toml/scanner.go
@@ -89,6 +89,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,

--- a/pkg/scanners/yaml/scanner.go
+++ b/pkg/scanners/yaml/scanner.go
@@ -85,6 +85,10 @@ func (s *Scanner) SetPolicyFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
+func (s *Scanner) SetInputSchema(_ interface{}) {
+	// handled by rego when option is passed on
+}
+
 func NewScanner(opts ...options.ScannerOption) *Scanner {
 	s := &Scanner{
 		options: opts,


### PR DESCRIPTION
For custom scanners, this PR enables the option to set the rego scanner's json schema from outside