### PR TITLE
feat(terraform): hashicorp/external provider

### DIFF
--- a/internal/adapters/terraform/adapt.go
+++ b/internal/adapters/terraform/adapt.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/azure"
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/cloudstack"
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/digitalocean"
+	"github.com/aquasecurity/defsec/internal/adapters/terraform/external"
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/github"
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/google"
 	"github.com/aquasecurity/defsec/internal/adapters/terraform/kubernetes"
@@ -20,6 +21,7 @@ func Adapt(modules terraform.Modules) *state.State {
 		Azure:        azure.Adapt(modules),
 		CloudStack:   cloudstack.Adapt(modules),
 		DigitalOcean: digitalocean.Adapt(modules),
+		External:     external.Adapt(modules),
 		GitHub:       github.Adapt(modules),
 		Google:       google.Adapt(modules),
 		Kubernetes:   kubernetes.Adapt(modules),

--- a/internal/adapters/terraform/external/adapt.go
+++ b/internal/adapters/terraform/external/adapt.go
@@ -1,0 +1,13 @@
+package external
+
+import (
+	"github.com/aquasecurity/defsec/internal/adapters/terraform/external/sources"
+	"github.com/aquasecurity/defsec/pkg/providers/external"
+	"github.com/aquasecurity/defsec/pkg/terraform"
+)
+
+func Adapt(modules terraform.Modules) external.External {
+	return external.External{
+		Sources: sources.Adapt(modules),
+	}
+}

--- a/internal/adapters/terraform/external/sources/adapt.go
+++ b/internal/adapters/terraform/external/sources/adapt.go
@@ -1,0 +1,42 @@
+package sources
+
+import (
+	"github.com/aquasecurity/defsec/pkg/providers/external"
+	"github.com/aquasecurity/defsec/pkg/terraform"
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func Adapt(modules terraform.Modules) []external.Source {
+	return adaptSources(modules)
+}
+
+func adaptSources(modules terraform.Modules) []external.Source {
+	var sources []external.Source
+	for _, module := range modules {
+		for _, resource := range module.GetDatasByType("external") {
+			sources = append(sources, adaptSource(resource))
+		}
+	}
+	return sources
+}
+
+func adaptSource(resource *terraform.Block) external.Source {
+	source := external.Source{
+		Metadata:   resource.GetMetadata(),
+		Program:    resource.GetAttribute("program").AsStringValueSliceOrEmpty(resource),
+		WorkingDir: resource.GetAttribute("working_dir").AsStringValueOrDefault("", resource),
+		Query:      defsecTypes.MapDefault(make(map[string]string), resource.GetMetadata()),
+	}
+	queryAttr := resource.GetAttribute("query")
+	if queryAttr.IsNotNil() {
+		query := make(map[string]string)
+		_ = queryAttr.Each(func(key, val cty.Value) {
+			if key.Type() == cty.String && val.Type() == cty.String {
+				query[key.AsString()] = val.AsString()
+			}
+		})
+		source.Query = defsecTypes.Map(query, queryAttr.GetMetadata())
+	}
+	return source
+}

--- a/internal/adapters/terraform/external/sources/adapt_test.go
+++ b/internal/adapters/terraform/external/sources/adapt_test.go
@@ -1,0 +1,73 @@
+package sources
+
+import (
+	"testing"
+
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/providers/external"
+
+	"github.com/aquasecurity/defsec/internal/adapters/terraform/tftestutil"
+
+	"github.com/aquasecurity/defsec/test/testutil"
+)
+
+func Test_Adapt(t *testing.T) {
+	tests := []struct {
+		name      string
+		terraform string
+		expected  []external.Source
+	}{
+		{
+			name: "basic",
+			terraform: `
+data "external" "example" {
+}
+`,
+			expected: []external.Source{
+				{
+					Metadata:   defsecTypes.NewTestMetadata(),
+					Program:    nil,
+					WorkingDir: defsecTypes.String("", defsecTypes.NewTestMetadata()),
+					Query:      defsecTypes.MapDefault(make(map[string]string), defsecTypes.NewTestMetadata()),
+				},
+			},
+		},
+		{
+			name: "basic",
+			terraform: `
+data "external" "example" {
+	program = ["python", "${path.module}/example-data-source.py"]
+	working_dir = "/tmp"
+	
+	query = {
+		# arbitrary map from strings to strings, passed
+		# to the external program as the data query.
+		id = "abc123"
+	}
+}
+			`,
+			expected: []external.Source{
+				{
+					Metadata: defsecTypes.NewTestMetadata(),
+					Program: []defsecTypes.StringValue{
+						defsecTypes.String("python", defsecTypes.NewTestMetadata()),
+						defsecTypes.String("./example-data-source.py", defsecTypes.NewTestMetadata()),
+					},
+					WorkingDir: defsecTypes.String("/tmp", defsecTypes.NewTestMetadata()),
+					Query: defsecTypes.MapDefault(map[string]string{
+						"id": "abc123",
+					}, defsecTypes.NewTestMetadata()),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules := tftestutil.CreateModulesFromSource(t, test.terraform, ".tf")
+			adapted := Adapt(modules)
+			testutil.AssertDefsecEqual(t, test.expected, adapted)
+		})
+	}
+}

--- a/pkg/providers/external/external.go
+++ b/pkg/providers/external/external.go
@@ -1,0 +1,5 @@
+package external
+
+type External struct {
+	Sources []Source
+}

--- a/pkg/providers/external/source.go
+++ b/pkg/providers/external/source.go
@@ -1,0 +1,12 @@
+package external
+
+import (
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+)
+
+type Source struct {
+	Metadata   defsecTypes.Metadata
+	Program    []defsecTypes.StringValue
+	WorkingDir defsecTypes.StringValue
+	Query      defsecTypes.MapValue
+}

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -17,6 +17,10 @@
       "type": "object",
       "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.digitalocean.DigitalOcean"
     },
+    "external": {
+      "type": "object",
+      "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.external.External"
+    },
     "github": {
       "type": "object",
       "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.github.GitHub"
@@ -4202,6 +4206,38 @@
         "enabled": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.BoolValue"
+        }
+      }
+    },
+    "github.com.aquasecurity.defsec.pkg.providers.external.External": {
+      "type": "object",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.external.Source"
+          }
+        }
+      }
+    },
+    "github.com.aquasecurity.defsec.pkg.providers.external.Source": {
+      "type": "object",
+      "properties": {
+        "program": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
+          }
+        },
+        "query": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.MapValue"
+        },
+        "workingdir": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
         }
       }
     },

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aquasecurity/defsec/pkg/providers/azure"
 	"github.com/aquasecurity/defsec/pkg/providers/cloudstack"
 	"github.com/aquasecurity/defsec/pkg/providers/digitalocean"
+	"github.com/aquasecurity/defsec/pkg/providers/external"
 	"github.com/aquasecurity/defsec/pkg/providers/github"
 	"github.com/aquasecurity/defsec/pkg/providers/google"
 	"github.com/aquasecurity/defsec/pkg/providers/kubernetes"
@@ -20,6 +21,7 @@ type State struct {
 	Azure        azure.Azure
 	CloudStack   cloudstack.CloudStack
 	DigitalOcean digitalocean.DigitalOcean
+	External     external.External
 	GitHub       github.GitHub
 	Google       google.Google
 	Kubernetes   kubernetes.Kubernetes


### PR DESCRIPTION
Adds a provider/parser for [hashicorp/external](https://registry.terraform.io/providers/hashicorp/external/latest/docs) which can be used to execute external programs, exposing the results as values within the template. I did not introduce any associated rules, but an example rule could restricting which external programs are allowed based on a rego rule for the `program` attribute.