### PR TITLE
fix(aws/sam): fix HttpApi access logging rule

### DIFF
--- a/avd_docs/aws/sam/AVD-AWS-0116/CloudFormation.md
+++ b/avd_docs/aws/sam/AVD-AWS-0116/CloudFormation.md
@@ -11,7 +11,7 @@ Resources:
       Name: Good SAM API example
       StageName: Prod
       Tracing: Activey
-      AccessLogSetting:
+      AccessLogSettings:
         DestinationArn: gateway-logging
         Format: json
 

--- a/internal/adapters/cloudformation/aws/sam/http_api.go
+++ b/internal/adapters/cloudformation/aws/sam/http_api.go
@@ -14,7 +14,7 @@ func getHttpApis(cfFile parser.FileContext) (apis []sam.HttpAPI) {
 			Metadata:             r.Metadata(),
 			Name:                 r.GetStringProperty("Name", ""),
 			DomainConfiguration:  getDomainConfiguration(r),
-			AccessLogging:        getAccessLogging(r),
+			AccessLogging:        getAccessLoggingV2(r),
 			DefaultRouteSettings: getRouteSettings(r),
 		}
 
@@ -22,6 +22,23 @@ func getHttpApis(cfFile parser.FileContext) (apis []sam.HttpAPI) {
 	}
 
 	return apis
+}
+
+func getAccessLoggingV2(r *parser.Resource) sam.AccessLogging {
+
+	logging := sam.AccessLogging{
+		Metadata:              r.Metadata(),
+		CloudwatchLogGroupARN: types.StringDefault("", r.Metadata()),
+	}
+
+	if access := r.GetProperty("AccessLogSettings"); access.IsNotNil() {
+		logging = sam.AccessLogging{
+			Metadata:              access.Metadata(),
+			CloudwatchLogGroupARN: access.GetStringProperty("DestinationArn", ""),
+		}
+	}
+
+	return logging
 }
 
 func getRouteSettings(r *parser.Resource) sam.RouteSettings {

--- a/rules/cloud/policies/aws/sam/enable_http_api_access_logging.cf.go
+++ b/rules/cloud/policies/aws/sam/enable_http_api_access_logging.cf.go
@@ -11,7 +11,7 @@ Resources:
       Name: Good SAM API example
       StageName: Prod
       Tracing: Activey
-      AccessLogSetting:
+      AccessLogSettings:
         DestinationArn: gateway-logging
         Format: json
 `,


### PR DESCRIPTION
`AWS::Serverless::HttpApi` uses `AccessLogSettings` instead of `AccessLogSetting`.

See
https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html#sam-httpapi-accesslogsettings