### PR TITLE
feat(docs): Support example annotations within rego policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ metadata_lint:
 docs:
 	go run ./cmd/avd_generator
 
+.PHONY: docs-test
+docs-test:
+	go test -v ./cmd/avd_generator/...
+
 .PHONY: id
 id:
 	@go run ./cmd/id

--- a/avd_docs/aws/rds/AVD-AWS-0082/Terraform.md
+++ b/avd_docs/aws/rds/AVD-AWS-0082/Terraform.md
@@ -5,7 +5,7 @@ Set the database to not be publicly accessible
  resource "aws_db_instance" "good_example" {
  	publicly_accessible = false
  }
- 
+
 ```
 
 #### Remediation Links

--- a/avd_docs/aws/rds/AVD-AWS-0180/CloudFormation.md
+++ b/avd_docs/aws/rds/AVD-AWS-0180/CloudFormation.md
@@ -1,5 +1,5 @@
 
-Set the database to not be publicly accessible
+Remove the public endpoint from the RDS instance'
 
 ```yaml---
 AWSTemplateFormatVersion: 2010-09-09

--- a/avd_docs/aws/rds/AVD-AWS-0180/Terraform.md
+++ b/avd_docs/aws/rds/AVD-AWS-0180/Terraform.md
@@ -1,0 +1,11 @@
+
+Remove the public endpoint from the RDS instance'
+
+```hcl
+ resource "aws_db_instance" "good_example" {
+ 	publicly_accessible = false
+ }
+
+```
+
+

--- a/cmd/avd_generator/main.go
+++ b/cmd/avd_generator/main.go
@@ -17,7 +17,6 @@ import (
 )
 
 func main() {
-
 	var generateCount int
 
 	for _, metadata := range registered.GetRegistered(framework.ALL) {
@@ -28,6 +27,7 @@ func main() {
 	fmt.Printf("\nGenerated %d files in avd_docs\n", generateCount)
 }
 
+// nolint: cyclop
 func writeDocsFile(meta rules.RegisteredRule, path string) {
 
 	tmpl, err := template.New("defsec").Parse(docsMarkdownTemplate)
@@ -116,15 +116,6 @@ func fail(msg string, args ...interface{}) {
 }
 
 func GetExampleValueFromFile(filename string, exampleType string) (string, error) {
-	//var file fs.File
-	//var err error
-	//if file, err = srcFS.Open(filename); err != nil {
-	//	return "", err
-	//}
-	//
-	//ff, _ := file.Stat()
-	//ff.Name()
-	//f, err := parser.ParseFile(token.NewFileSet(), ff.Name(), nil, parser.AllErrors)
 	f, err := parser.ParseFile(token.NewFileSet(), filename, nil, parser.AllErrors)
 	if err != nil {
 		return "", err

--- a/cmd/avd_generator/main.go
+++ b/cmd/avd_generator/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	goast "go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,21 +21,21 @@ func main() {
 	var generateCount int
 
 	for _, metadata := range registered.GetRegistered(framework.ALL) {
-		writeDocsFile(metadata)
+		writeDocsFile(metadata, "avd_docs")
 		generateCount++
 	}
 
 	fmt.Printf("\nGenerated %d files in avd_docs\n", generateCount)
 }
 
-func writeDocsFile(meta rules.RegisteredRule) {
+func writeDocsFile(meta rules.RegisteredRule, path string) {
 
 	tmpl, err := template.New("defsec").Parse(docsMarkdownTemplate)
 	if err != nil {
 		fail("error occurred creating the template %v\n", err)
 	}
 
-	docpath := filepath.Join("avd_docs",
+	docpath := filepath.Join(path,
 		strings.ToLower(meta.Rule().Provider.ConstName()),
 		strings.ToLower(strings.ReplaceAll(meta.Rule().Service, "-", "")),
 		meta.Rule().AVDID,
@@ -54,6 +57,14 @@ func writeDocsFile(meta rules.RegisteredRule) {
 
 	if meta.Rule().Terraform != nil {
 		if len(meta.Rule().Terraform.GoodExamples) > 0 || len(meta.Rule().Terraform.Links) > 0 {
+			if meta.Rule().RegoPackage != "" { // get examples from file as rego rules don't have embedded
+				value, err := GetExampleValueFromFile(meta.Rule().Terraform.GoodExamples[0], "GoodExamples")
+				if err != nil {
+					fail("error retrieving examples from metadata: %v\n", err)
+				}
+				meta.Rule().Terraform.GoodExamples = []string{value}
+			}
+
 			tmpl, err := template.New("terraform").Parse(terraformMarkdownTemplate)
 			if err != nil {
 				fail("error occurred creating the template %v\n", err)
@@ -73,6 +84,14 @@ func writeDocsFile(meta rules.RegisteredRule) {
 
 	if meta.Rule().CloudFormation != nil {
 		if len(meta.Rule().CloudFormation.GoodExamples) > 0 || len(meta.Rule().CloudFormation.Links) > 0 {
+			if meta.Rule().RegoPackage != "" { // get examples from file as rego rules don't have embedded
+				value, err := GetExampleValueFromFile(meta.Rule().CloudFormation.GoodExamples[0], "GoodExamples")
+				if err != nil {
+					fail("error retrieving examples from metadata: %v\n", err)
+				}
+				meta.Rule().CloudFormation.GoodExamples = []string{value}
+			}
+
 			tmpl, err := template.New("cloudformation").Parse(cloudformationMarkdownTemplate)
 			if err != nil {
 				fail("error occurred creating the template %v\n", err)
@@ -94,6 +113,43 @@ func writeDocsFile(meta rules.RegisteredRule) {
 func fail(msg string, args ...interface{}) {
 	fmt.Printf(msg, args...)
 	os.Exit(1)
+}
+
+func GetExampleValueFromFile(filename string, exampleType string) (string, error) {
+	//var file fs.File
+	//var err error
+	//if file, err = srcFS.Open(filename); err != nil {
+	//	return "", err
+	//}
+	//
+	//ff, _ := file.Stat()
+	//ff.Name()
+	//f, err := parser.ParseFile(token.NewFileSet(), ff.Name(), nil, parser.AllErrors)
+	f, err := parser.ParseFile(token.NewFileSet(), filename, nil, parser.AllErrors)
+	if err != nil {
+		return "", err
+	}
+
+	for _, d := range f.Decls {
+		switch decl := d.(type) {
+		case *goast.GenDecl:
+			for _, spec := range decl.Specs {
+				switch spec := spec.(type) {
+				case *goast.ValueSpec:
+					for _, id := range spec.Names {
+						switch v := id.Obj.Decl.(*goast.ValueSpec).Values[0].(type) {
+						case *goast.CompositeLit:
+							value := v.Elts[0].(*goast.BasicLit).Value
+							if strings.Contains(id.Name, exampleType) {
+								return strings.ReplaceAll(value, "`", ""), nil
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("exampleType %s not found in file: %s", exampleType, filename)
 }
 
 var docsMarkdownTemplate = `

--- a/cmd/avd_generator/main_test.go
+++ b/cmd/avd_generator/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/defsec/pkg/framework"
+	registered "github.com/aquasecurity/defsec/pkg/rules"
+)
+
+func init() { // change the pwd for the test to top level defesc dir
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "../..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Test_AVDPageGeneration(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+
+	var generateCount int
+	for _, metadata := range registered.GetRegistered(framework.ALL) {
+		writeDocsFile(metadata, tmpDir)
+		generateCount++
+	}
+	fmt.Printf("\nGenerated %d files in avd_docs\n", generateCount)
+
+	// check golang policies
+	b, err := os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0077", "Terraform.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `hcl
+ resource "aws_rds_cluster" "good_example" {
+ 	cluster_identifier      = "aurora-cluster-demo"
+ 	engine                  = "aurora-mysql"
+ 	engine_version          = "5.7.mysql_aurora.2.03.2"
+ 	availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
+ 	database_name           = "mydb"
+ 	master_username         = "foo"
+ 	master_password         = "bar"
+ 	backup_retention_period = 5
+ 	preferred_backup_window = "07:00-09:00"
+   }`)
+
+	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0077", "CloudFormation.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `yaml---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Good example
+Resources:
+  Queue:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      BackupRetentionPeriod: 30
+`)
+
+	// check rego policies
+	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "Terraform.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `hcl
+ resource "aws_db_instance" "good_example" {
+ 	publicly_accessible = false
+ }`)
+
+	b, err = os.ReadFile(filepath.Join(tmpDir, "aws/rds/AVD-AWS-0180", "CloudFormation.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `yaml---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Good example
+Resources:
+  Queue:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: false`)
+}

--- a/internal/rules/aws/rds/no_public_db_access.cf.go
+++ b/internal/rules/aws/rds/no_public_db_access.cf.go
@@ -3,7 +3,7 @@ package rds
 var cloudFormationNoPublicDbAccessGoodExamples = []string{
 	`---
 AWSTemplateFormatVersion: 2010-09-09
-Description: Bad example
+Description: Good example
 Resources:
   Queue:
     Type: AWS::RDS::DBInstance

--- a/internal/rules/aws/rds/no_public_db_access.tf.go
+++ b/internal/rules/aws/rds/no_public_db_access.tf.go
@@ -5,7 +5,7 @@ var terraformNoPublicDbAccessGoodExamples = []string{
  resource "aws_db_instance" "good_example" {
  	publicly_accessible = false
  }
- `,
+`,
 }
 
 var terraformNoPublicDbAccessBadExamples = []string{
@@ -13,7 +13,7 @@ var terraformNoPublicDbAccessBadExamples = []string{
  resource "aws_db_instance" "bad_example" {
  	publicly_accessible = true
  }
- `,
+`,
 }
 
 var terraformNoPublicDbAccessLinks = []string{

--- a/internal/rules/policies/cloud/policies/aws/rds/disable_public_access.rego
+++ b/internal/rules/policies/cloud/policies/aws/rds/disable_public_access.rego
@@ -16,6 +16,11 @@
 #   input:
 #     selector:
 #     - type: cloud
+#   terraform:
+#       good_examples: "internal/rules/aws/rds/no_public_db_access.tf.go"
+#   cloud_formation:
+#       good_examples: "internal/rules/aws/rds/no_public_db_access.cf.go"
+
 package builtin.aws.rds.aws0180
 
 deny[res] {


### PR DESCRIPTION
See this rego policy for an example: https://github.com/aquasecurity/defsec/blob/954d15e5b61a0e8a8731a5d8c3f3cf5009e235a6/internal/rules/policies/cloud/policies/aws/rds/disable_public_access.rego#L19-L22

```rego
# METADATA
# title: "RDS Publicly Accessible"
# description: "Ensures RDS instances are not launched into the public cloud."
# scope: package
# schemas:
# - input: schema.input
# related_resources:
# - http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html
# custom:
#   avd_id: AVD-AWS-0180
#   provider: aws
#   service: rds
#   severity: HIGH
#   short_code: enable-public-access
#   recommended_action: "Remove the public endpoint from the RDS instance'"
#   input:
#     selector:
#     - type: cloud
#   terraform:
#       good_examples: "internal/rules/aws/rds/no_public_db_access.tf.go"
#   cloud_formation:
#       good_examples: "internal/rules/aws/rds/no_public_db_access.cf.go"

package builtin.aws.rds.aws0180

deny[res] {
	instance := input.aws.rds.instances[_]
	instance.publicaccess.value
	res := result.new("Instance has Public Access enabled", instance.publicaccess)
}
```



Addresses: https://github.com/aquasecurity/trivy/issues/3440


Signed-off-by: Simar <simar@linux.com
