### PR TITLE
fix(selectors): Evaluate policy when no selectors are present

### DIFF
--- a/pkg/rego/scanner.go
+++ b/pkg/rego/scanner.go
@@ -285,7 +285,7 @@ func isPolicyWithSubtype(sourceType types.Source) bool {
 }
 
 func checkSubtype(ii map[string]interface{}, provider string, subTypes []SubType) bool {
-	if len(subTypes) == 0 { // policy always applies if no subtypes
+	if len(subTypes) == 0 {
 		return true
 	}
 
@@ -316,6 +316,10 @@ func isPolicyApplicable(staticMetadata *StaticMetadata, inputs ...Input) bool {
 				// TODO(simar): Add other providers
 				if !strings.Contains(strings.Join([]string{"kind", "aws", "azure"}, ","), provider) {
 					continue
+				}
+
+				if len(staticMetadata.InputOptions.Selectors) == 0 { // policy always applies if no selectors
+					return true
 				}
 
 				// check metadata for subtype

--- a/pkg/scanners/cloud/aws/scanner_test.go
+++ b/pkg/scanners/cloud/aws/scanner_test.go
@@ -105,7 +105,7 @@ deny[res] {
 			expectedResults: struct {
 				totalResults int
 				summaries    []string
-			}{totalResults: 0},
+			}{totalResults: 2, summaries: []string{"RDS Publicly Accessible", "CloudTrail Bucket Delete Policy"}},
 		},
 		{
 			name: "selector is empty",
@@ -146,7 +146,7 @@ deny[res] {
 			expectedResults: struct {
 				totalResults int
 				summaries    []string
-			}{totalResults: 0},
+			}{totalResults: 2, summaries: []string{"RDS Publicly Accessible", "CloudTrail Bucket Delete Policy"}},
 		},
 		{
 			name: "selector without subtype",


### PR DESCRIPTION
Currently we do this check at the wrong place, it should be evaluated prior.

This should also take care of the situation where no selectors are defined at all.

Signed-off-by: Simar <simar@linux.com>