### PR TITLE
fix(rules): Update list of outdated ELB TLS policies

### DIFF
--- a/avd_docs/aws/elb/AVD-AWS-0047/Terraform.md
+++ b/avd_docs/aws/elb/AVD-AWS-0047/Terraform.md
@@ -3,7 +3,7 @@ Use a more recent TLS/SSL policy for the load balancer
 
 ```hcl
  resource "aws_alb_listener" "good_example" {
- 	ssl_policy = "ELBSecurityPolicy-TLS-1-2-2017-01"
+ 	ssl_policy = "ELBSecurityPolicy-TLS13-1-2-2021-06"
  	protocol = "HTTPS"
  }
  

--- a/rules/cloud/policies/aws/elb/use_secure_tls_policy.go
+++ b/rules/cloud/policies/aws/elb/use_secure_tls_policy.go
@@ -10,9 +10,15 @@ import (
 
 var outdatedSSLPolicies = []string{
 	"ELBSecurityPolicy-2015-05",
-	"ELBSecurityPolicy-TLS-1-0-2015-04",
 	"ELBSecurityPolicy-2016-08",
+	"ELBSecurityPolicy-FS-2018-06",
+	"ELBSecurityPolicy-FS-1-1-2019-08",
+	"ELBSecurityPolicy-TLS-1-0-2015-04",
 	"ELBSecurityPolicy-TLS-1-1-2017-01",
+	"ELBSecurityPolicy-TLS13-1-0-2021-06",
+	"ELBSecurityPolicy-TLS13-1-1-2021-06",
+	"ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
+	"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
 }
 
 var CheckUseSecureTlsPolicy = rules.Register(

--- a/rules/cloud/policies/aws/elb/use_secure_tls_policy.tf.go
+++ b/rules/cloud/policies/aws/elb/use_secure_tls_policy.tf.go
@@ -3,7 +3,7 @@ package elb
 var terraformUseSecureTlsPolicyGoodExamples = []string{
 	`
  resource "aws_alb_listener" "good_example" {
- 	ssl_policy = "ELBSecurityPolicy-TLS-1-2-2017-01"
+ 	ssl_policy = "ELBSecurityPolicy-TLS13-1-2-2021-06"
  	protocol = "HTTPS"
  }
  `,

--- a/rules/cloud/policies/aws/elb/use_secure_tls_policy_test.go
+++ b/rules/cloud/policies/aws/elb/use_secure_tls_policy_test.go
@@ -53,6 +53,23 @@ func TestCheckUseSecureTlsPolicy(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Load balancer listener using TLS v1.3",
+			input: elb.ELB{
+				LoadBalancers: []elb.LoadBalancer{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						Listeners: []elb.Listener{
+							{
+								Metadata:  defsecTypes.NewTestMetadata(),
+								TLSPolicy: defsecTypes.String("ELBSecurityPolicy-TLS13-1-2-2021-06", defsecTypes.NewTestMetadata()),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
AWS has added additional ELB security policies that support TLS v1.3. Some of them should be treated as outdated/unsafe, as they enable ciphers that are effectively deprecated.

https://aws.amazon.com/about-aws/whats-new/2023/03/application-load-balancer-tls-1-3/

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies

Reasoning for each addition:
* `ELBSecurityPolicy-FS-2018-06` -- supports TLS v1.0 and v1.1
* `ELBSecurityPolicy-FS-1-1-2019-08` -- supports TLS v1.1
* `ELBSecurityPolicy-TLS13-1-0-2021-06` -- supports TLS v1.0 and v1.1
* `ELBSecurityPolicy-TLS13-1-1-2021-06` -- supports TLS v1.1
* `ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06` -- supports non elliptic curve cryptography cipher suites
* `ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06` -- supports non elliptic curve cryptography cipher suites