### PR TITLE
api_server_authorized_ip_ranges deprecated

### DIFF
--- a/internal/adapters/terraform/azure/container/adapt.go
+++ b/internal/adapters/terraform/azure/container/adapt.go
@@ -56,8 +56,10 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 	privateClusterEnabledAttr := resource.GetAttribute("private_cluster_enabled")
 	cluster.EnablePrivateCluster = privateClusterEnabledAttr.AsBoolValueOrDefault(false, resource)
 
-	apiServerAuthorizedIPRangesAttr := resource.GetAttribute("api_server_authorized_ip_ranges")
-	cluster.APIServerAuthorizedIPRanges = apiServerAuthorizedIPRangesAttr.AsStringValues()
+	if apiServerBlock := resource.GetBlock("api_server_access_profile"); apiServerBlock.IsNotNil() {
+		authorizedIPRangesAttr := apiServerBlock.GetAttribute("authorized_ip_ranges")
+		cluster.APIServerAuthorizedIPRanges = authorizedIPRangesAttr.AsStringValues()
+	}
 
 	addonProfileBlock := resource.GetBlock("addon_profile")
 	if addonProfileBlock.IsNotNil() {

--- a/internal/adapters/terraform/azure/container/adapt_test.go
+++ b/internal/adapters/terraform/azure/container/adapt_test.go
@@ -30,9 +30,13 @@ func Test_adaptCluster(t *testing.T) {
 				  network_policy = "calico"
 				}
 
-				api_server_authorized_ip_ranges = [
+				api_server_access_profile {
+
+					authorized_ip_ranges = [
 					"1.2.3.4/32"
-				]
+					]
+		
+				}
 
 				addon_profile {
 					oms_agent {
@@ -171,10 +175,14 @@ func TestLines(t *testing.T) {
 		network_profile {
 		  network_policy = "calico"
 		}
+        
+		api_server_access_profile {
 
-		api_server_authorized_ip_ranges = [
+		    authorized_ip_ranges = [
 			"1.2.3.4/32"
-		]
+		    ]
+
+		}
 
 		addon_profile {
 			oms_agent {
@@ -202,23 +210,23 @@ func TestLines(t *testing.T) {
 	assert.Equal(t, 6, cluster.NetworkProfile.NetworkPolicy.GetMetadata().Range().GetStartLine())
 	assert.Equal(t, 6, cluster.NetworkProfile.NetworkPolicy.GetMetadata().Range().GetEndLine())
 
-	assert.Equal(t, 9, cluster.APIServerAuthorizedIPRanges[0].GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 11, cluster.APIServerAuthorizedIPRanges[0].GetMetadata().Range().GetEndLine())
+	assert.Equal(t, 11, cluster.APIServerAuthorizedIPRanges[0].GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 13, cluster.APIServerAuthorizedIPRanges[0].GetMetadata().Range().GetEndLine())
 
-	assert.Equal(t, 13, cluster.AddonProfile.Metadata.Range().GetStartLine())
-	assert.Equal(t, 17, cluster.AddonProfile.Metadata.Range().GetEndLine())
+	assert.Equal(t, 17, cluster.AddonProfile.Metadata.Range().GetStartLine())
+	assert.Equal(t, 21, cluster.AddonProfile.Metadata.Range().GetEndLine())
 
-	assert.Equal(t, 14, cluster.AddonProfile.OMSAgent.Metadata.Range().GetStartLine())
-	assert.Equal(t, 16, cluster.AddonProfile.OMSAgent.Metadata.Range().GetEndLine())
+	assert.Equal(t, 18, cluster.AddonProfile.OMSAgent.Metadata.Range().GetStartLine())
+	assert.Equal(t, 20, cluster.AddonProfile.OMSAgent.Metadata.Range().GetEndLine())
 
-	assert.Equal(t, 15, cluster.AddonProfile.OMSAgent.Enabled.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 15, cluster.AddonProfile.OMSAgent.Enabled.GetMetadata().Range().GetEndLine())
+	assert.Equal(t, 19, cluster.AddonProfile.OMSAgent.Enabled.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 19, cluster.AddonProfile.OMSAgent.Enabled.GetMetadata().Range().GetEndLine())
 
-	assert.Equal(t, 19, cluster.RoleBasedAccessControl.Metadata.Range().GetStartLine())
-	assert.Equal(t, 21, cluster.RoleBasedAccessControl.Metadata.Range().GetEndLine())
+	assert.Equal(t, 23, cluster.RoleBasedAccessControl.Metadata.Range().GetStartLine())
+	assert.Equal(t, 25, cluster.RoleBasedAccessControl.Metadata.Range().GetEndLine())
 
-	assert.Equal(t, 20, cluster.RoleBasedAccessControl.Enabled.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 20, cluster.RoleBasedAccessControl.Enabled.GetMetadata().Range().GetEndLine())
+	assert.Equal(t, 24, cluster.RoleBasedAccessControl.Enabled.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 24, cluster.RoleBasedAccessControl.Enabled.GetMetadata().Range().GetEndLine())
 }
 
 func TestWithLocals(t *testing.T) {
@@ -235,9 +243,13 @@ locals {
 
 resource "azurerm_kubernetes_cluster" "aks" {
   # not working
-  api_server_authorized_ip_ranges = local.ip_whitelist
+  api_server_access_profile {
+   authorized_ip_ranges = local.ip_whitelist
+  }
   # working
-  # api_server_authorized_ip_ranges = concat(var.ip_whitelist, split(",", data.azurerm_public_ip.example.ip_address))
+  api_server_access_profile {
+   authorized_ip_ranges = concat(var.ip_whitelist, split(",", data.azurerm_public_ip.example.ip_address))
+  }
 }`
 
 	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")

--- a/rules/cloud/policies/azure/container/limit_authorized_ips.tf.go
+++ b/rules/cloud/policies/azure/container/limit_authorized_ips.tf.go
@@ -3,9 +3,13 @@ package container
 var terraformLimitAuthorizedIpsGoodExamples = []string{
 	`
  resource "azurerm_kubernetes_cluster" "good_example" {
-     api_server_authorized_ip_ranges = [
+	api_server_access_profile {
+		authorized_ip_ranges = [
  		"1.2.3.4/32"
  	]
+
+	}
+     
  }
  `,
 }


### PR DESCRIPTION
this commit fixes #3850 https://github.com/aquasecurity/trivy/issues/3850