### PR TITLE
Fix: `AVD-KCV-0028` and `AVD-KCV-0029` checks

### DIFF
--- a/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file.rego
@@ -22,7 +22,7 @@ import data.lib.kubernetes
 check_flag[container] {
 	container := kubernetes.containers[_]
 	kubernetes.is_apiserver(container)
-	kubernetes.command_has_flag(container.command, "--client-ca-file")
+	not kubernetes.command_has_flag(container.command, "--client-ca-file")
 }
 
 deny[res] {

--- a/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file_test.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file_test.rego
@@ -39,6 +39,6 @@ test_client_ca_file_is_not_set {
 		}]},
 	}
 
-	count(r) == 0
+	count(r) == 1
 	r[_].msg == "Ensure that the --client-ca-file argument is set as appropriate"
 }

--- a/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file_test.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file_test.rego
@@ -18,8 +18,7 @@ test_client_ca_file_is_set {
 		}]},
 	}
 
-	count(r) == 1
-	r[_].msg == "Ensure that the --client-ca-file argument is set as appropriate"
+	count(r) == 0
 }
 
 test_client_ca_file_is_not_set {
@@ -41,4 +40,5 @@ test_client_ca_file_is_not_set {
 	}
 
 	count(r) == 0
+	r[_].msg == "Ensure that the --client-ca-file argument is set as appropriate"
 }

--- a/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile.rego
@@ -22,7 +22,7 @@ import data.lib.kubernetes
 check_flag[container] {
 	container := kubernetes.containers[_]
 	kubernetes.is_apiserver(container)
-	kubernetes.command_has_flag(container.command, "--etcd-cafile")
+	not kubernetes.command_has_flag(container.command, "--etcd-cafile")
 }
 
 deny[res] {

--- a/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile_test.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile_test.rego
@@ -18,8 +18,7 @@ test_etcd_cafile_is_set {
 		}]},
 	}
 
-	count(r) == 1
-	r[_].msg == "Ensure that the --etcd-cafile argument is set as appropriate"
+	count(r) == 0
 }
 
 test_etcd_cafile_is_not_set {
@@ -40,5 +39,6 @@ test_etcd_cafile_is_not_set {
 		}]},
 	}
 
-	count(r) == 0
+	count(r) == 1
+	r[_].msg == "Ensure that the --etcd-cafile argument is set as appropriate"
 }


### PR DESCRIPTION
Now [client_ca_file.rego](https://github.com/aquasecurity/defsec/blob/master/rules/kubernetes/policies/cisbenchmarks/apiserver/client_ca_file.rego#L25) and [etcd_cafile.rego](https://github.com/aquasecurity/defsec/blob/master/rules/kubernetes/policies/cisbenchmarks/apiserver/etcd_cafile.rego#L25) checks fail when `--client-ca-file` and `--etcd-cafile` flags are set in `kube-apiserver` pod spec respectively. 

But CIS benchmark spec says that `--client-ca-file` and `--etcd-cafile` flags must be set with proper values.

This PR fixes this inaccuracy