### PR TITLE
Fix: correct search for control plane containers

### DIFF
--- a/rules/kubernetes/lib/kubernetes.rego
+++ b/rules/kubernetes/lib/kubernetes.rego
@@ -179,17 +179,17 @@ command_has_flag(command, flag) {
 }
 
 is_controllermananager(container) {
-	regex.match("kube-controller-manager", container.command[0])
+	regex.match("^kube-controller-manager$", container.command[0])
 }
 
 is_etcd(container) {
-	regex.match("etcd", container.command[0])
+	regex.match("^etcd$", container.command[0])
 }
 
 is_scheduler(container) {
-	regex.match("kube-scheduler", container.command[0])
+	regex.match("^kube-scheduler$", container.command[0])
 }
 
 is_apiserver(container) {
-	regex.match("kube-apiserver", container.command[0])
+	regex.match("^kube-apiserver$", container.command[0])
 }

--- a/rules/kubernetes/lib/kubernetes.rego
+++ b/rules/kubernetes/lib/kubernetes.rego
@@ -179,17 +179,17 @@ command_has_flag(command, flag) {
 }
 
 is_controllermananager(container) {
-	regex.match("^kube-controller-manager$", container.command[0])
+	regex.match("^(.*\/)?kube-controller-manager$", container.command[0])
 }
 
 is_etcd(container) {
-	regex.match("^etcd$", container.command[0])
+	regex.match("^(.*\/)?etcd$", container.command[0])
 }
 
 is_scheduler(container) {
-	regex.match("^kube-scheduler$", container.command[0])
+	regex.match("^(.*\/)?kube-scheduler$", container.command[0])
 }
 
 is_apiserver(container) {
-	regex.match("^kube-apiserver$", container.command[0])
+	regex.match("^(.*\/)?kube-apiserver$", container.command[0])
 }

--- a/rules/kubernetes/lib/kubernetes.rego
+++ b/rules/kubernetes/lib/kubernetes.rego
@@ -179,17 +179,17 @@ command_has_flag(command, flag) {
 }
 
 is_controllermananager(container) {
-	regex.match("^(.*\/)?kube-controller-manager$", container.command[0])
+	regex.match("^(.*/)?kube-controller-manager$", container.command[0])
 }
 
 is_etcd(container) {
-	regex.match("^(.*\/)?etcd$", container.command[0])
+	regex.match("^(.*/)?etcd$", container.command[0])
 }
 
 is_scheduler(container) {
-	regex.match("^(.*\/)?kube-scheduler$", container.command[0])
+	regex.match("^(.*/)?kube-scheduler$", container.command[0])
 }
 
 is_apiserver(container) {
-	regex.match("^(.*\/)?kube-apiserver$", container.command[0])
+	regex.match("^(.*/)?kube-apiserver$", container.command[0])
 }

--- a/rules/kubernetes/lib/kubernetes_test.rego
+++ b/rules/kubernetes/lib/kubernetes_test.rego
@@ -44,7 +44,7 @@ test_cron_job {
 }
 
 test_deployment {
-	# spec -> template    
+	# spec -> template
 	test_pods := pods with input as {
 		"apiVersion": "v1",
 		"kind": "Deployment",
@@ -65,7 +65,7 @@ test_deployment {
 }
 
 test_stateful_set {
-	# spec -> template    
+	# spec -> template
 	test_pods := pods with input as {
 		"apiVersion": "v1",
 		"kind": "StatefulSet",
@@ -86,7 +86,7 @@ test_stateful_set {
 }
 
 test_daemon_set {
-	# spec -> template    
+	# spec -> template
 	test_pods := pods with input as {
 		"apiVersion": "v1",
 		"kind": "DaemonSet",
@@ -107,7 +107,7 @@ test_daemon_set {
 }
 
 test_replica_set {
-	# spec -> template    
+	# spec -> template
 	test_pods := pods with input as {
 		"apiVersion": "v1",
 		"kind": "ReplicaSet",
@@ -128,7 +128,7 @@ test_replica_set {
 }
 
 test_replication_controller {
-	# spec -> template    
+	# spec -> template
 	test_pods := pods with input as {
 		"apiVersion": "v1",
 		"kind": "ReplicationController",
@@ -149,7 +149,7 @@ test_replication_controller {
 }
 
 test_job {
-	# spec -> template    
+	# spec -> template
 	test_pods := pods with input as {
 		"apiVersion": "v1",
 		"kind": "Job",
@@ -203,4 +203,269 @@ test_containers {
 	}
 
 	test_containers[_].name == "hello-containers"
+}
+
+test_isapiserver_has_valid_container {
+	apiserver_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "kube-apiserver",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": ["kube-apiserver-invalid"],
+				"name": "invalid-1",
+			},
+			{
+				"command": [
+					"/usr/bin/kube-apiserver",
+					"--test-flag=test",
+				],
+				"name": "valid-1",
+			},
+			{
+				"command": ["invalid-kube-apiserver"],
+				"name": "invalid-2",
+			},
+			{
+				"command": [
+					"kube-apiserver",
+					"--test-flag=test",
+				],
+				"name": "valid-2",
+			},
+		]},
+	}
+
+	is_apiserver(apiserver_container)
+	any([apiserver_container.name == "valid-1", apiserver_container.name == "valid-2"])
+}
+
+test_isapiserver_has_not_valid_container {
+	apiserver_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "kube-apiserver",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": [
+					"/usr/bin-kube-apiserver",
+					"--test-flag=test",
+				],
+				"name": "invalid-1",
+			},
+			{
+				"command": ["kube-apiserver-invalid"],
+				"name": "invalid-2",
+			},
+			{
+				"command": ["kube-apiserver-invalid"],
+				"name": "invalid-3",
+			},
+		]},
+	}
+	not is_apiserver(apiserver_container)
+}
+
+test_etcd_has_valid_container {
+	etcd_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": ["etcd-invalid"],
+				"name": "invalid-1",
+			},
+			{
+				"command": [
+					"/usr/bin/etcd",
+					"--test-flag=test",
+				],
+				"name": "valid-1",
+			},
+			{
+				"command": ["invalid-etcd"],
+				"name": "invalid-2",
+			},
+			{
+				"command": [
+					"etcd",
+					"--test-flag=test",
+				],
+				"name": "valid-2",
+			},
+		]},
+	}
+	is_etcd(etcd_container)
+	any([etcd_container.name == "valid-1", etcd_container.name == "valid-2"])
+}
+
+test_etcd_has_not_valid_container {
+	etcd_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "etcd",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": [
+					"/usr/bin-etcd",
+					"--test-flag=test",
+				],
+				"name": "invalid-1",
+			},
+			{
+				"command": ["etcd-invalid"],
+				"name": "invalid-2",
+			},
+			{
+				"command": ["etcd-invalid"],
+				"name": "invalid-3",
+			},
+		]},
+	}
+	not is_etcd(etcd_container)
+}
+
+test_controllermananager_has_valid_container {
+	controllermananager_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "kube-controller-manager",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": ["kube-controller-manager-invalid"],
+				"name": "invalid-1",
+			},
+			{
+				"command": [
+					"/usr/bin/kube-controller-manager",
+					"--test-flag=test",
+				],
+				"name": "valid-1",
+			},
+			{
+				"command": ["invalid-kube-controller-manager"],
+				"name": "invalid-2",
+			},
+			{
+				"command": [
+					"kube-controller-manager",
+					"--test-flag=test",
+				],
+				"name": "valid-2",
+			},
+		]},
+	}
+	is_controllermananager(controllermananager_container)
+	any([controllermananager_container.name == "valid-1", controllermananager_container.name == "valid-2"])
+}
+
+test_controllermananager_has_not_valid_container {
+	controllermananager_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "kube-controller-manager",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": [
+					"/usr/bin-kube-controller-manager",
+					"--test-flag=test",
+				],
+				"name": "invalid-1",
+			},
+			{
+				"command": ["kube-controller-manager-invalid"],
+				"name": "invalid-2",
+			},
+			{
+				"command": ["kube-controller-manager-invalid"],
+				"name": "invalid-3",
+			},
+		]},
+	}
+	not is_controllermananager(controllermananager_container)
+}
+
+test_scheduler_has_valid_container {
+	scheduler_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "kube-scheduler",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": ["kube-scheduler-invalid"],
+				"name": "invalid-1",
+			},
+			{
+				"command": [
+					"/usr/bin/kube-scheduler",
+					"--test-flag=test",
+				],
+				"name": "valid-1",
+			},
+			{
+				"command": ["invalid-kube-scheduler"],
+				"name": "invalid-2",
+			},
+			{
+				"command": [
+					"kube-scheduler",
+					"--test-flag=test",
+				],
+				"name": "valid-2",
+			},
+		]},
+	}
+	is_scheduler(scheduler_container)
+	any([scheduler_container.name == "valid-1", scheduler_container.name == "valid-2"])
+}
+
+test_scheduler_has_not_valid_container {
+	scheduler_container := containers[_] with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {
+			"name": "kube-scheduler",
+			"namespace": "kube-system",
+		},
+		"spec": {"containers": [
+			{
+				"command": [
+					"/usr/bin-kube-scheduler",
+					"--test-flag=test",
+				],
+				"name": "invalid-1",
+			},
+			{
+				"command": ["kube-scheduler-invalid"],
+				"name": "invalid-2",
+			},
+			{
+				"command": ["kube-scheduler-invalid"],
+				"name": "invalid-3",
+			},
+		]},
+	}
+	not is_scheduler(scheduler_container)
 }


### PR DESCRIPTION
Now in functions `is_apiserver`, `is_etcd`, `is_controllermananager` and `is_scheduler` regexes for first command entry are not "strict", so when there is more than one container in control plane pod with first command entries, for example, `kube-apiserver` and `kube-apiserver-healthcheck` - checks for control plane containers would be applied also for another (non control plane) container. This produces false negative check results.

In this PR I proposed solution for fixing this behavior.