### PR TITLE
fix(terraform): Use absolute path for filesystem to load tfvars

### DIFF
--- a/pkg/scanners/terraform/parser/load_vars.go
+++ b/pkg/scanners/terraform/parser/load_vars.go
@@ -14,8 +14,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func getAbsPath(path string) (string, error) {
-	p, err := filepath.Abs(path)
+func getAbsPath(inputPath string) (string, error) {
+	p, err := filepath.Abs(inputPath)
 	if err != nil {
 		return "", fmt.Errorf("unable to determine path: %w", err)
 	}
@@ -71,6 +71,7 @@ func loadTFVarsFile(srcFS fs.FS, filename string) (map[string]cty.Value, error) 
 	if err != nil {
 		return nil, err
 	}
+	absPath = filepath.ToSlash(absPath) // in memory fs is only slash based
 
 	src, err := fs.ReadFile(srcFS, absPath)
 	if err != nil {

--- a/pkg/scanners/terraform/parser/load_vars.go
+++ b/pkg/scanners/terraform/parser/load_vars.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -12,6 +13,23 @@ import (
 	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/zclconf/go-cty/cty"
 )
+
+func getAbsPath(path string) (string, error) {
+	p, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine path: %w", err)
+	}
+	switch runtime.GOOS {
+	case "windows":
+		if volume := filepath.VolumeName(p); volume != "" {
+			p = strings.TrimPrefix(filepath.ToSlash(p), volume+"/")
+			return filepath.FromSlash(p), nil
+		}
+		return strings.TrimPrefix(filepath.Clean(p), fmt.Sprintf("%c", os.PathSeparator)), nil
+	default:
+		return strings.TrimPrefix(filepath.Clean(p), fmt.Sprintf("%c", os.PathSeparator)), nil
+	}
+}
 
 func loadTFVars(srcFS fs.FS, filenames []string) (map[string]cty.Value, error) {
 	combinedVars := make(map[string]cty.Value)
@@ -44,20 +62,24 @@ func loadTFVars(srcFS fs.FS, filenames []string) (map[string]cty.Value, error) {
 }
 
 func loadTFVarsFile(srcFS fs.FS, filename string) (map[string]cty.Value, error) {
-
 	inputVars := make(map[string]cty.Value)
 	if filename == "" {
 		return inputVars, nil
 	}
 
-	src, err := fs.ReadFile(srcFS, filepath.ToSlash(filename))
+	absPath, err := getAbsPath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	src, err := fs.ReadFile(srcFS, absPath)
 	if err != nil {
 		return nil, err
 	}
 
 	var attrs hcl.Attributes
-	if strings.HasSuffix(filename, ".json") {
-		variableFile, err := hcljson.Parse(src, filename)
+	if strings.HasSuffix(absPath, ".json") {
+		variableFile, err := hcljson.Parse(src, absPath)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +88,7 @@ func loadTFVarsFile(srcFS fs.FS, filename string) (map[string]cty.Value, error) 
 			return nil, err
 		}
 	} else {
-		variableFile, err := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
+		variableFile, err := hclsyntax.ParseConfig(src, absPath, hcl.Pos{Line: 1, Column: 1})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scanners/terraform/parser/load_vars_test.go
+++ b/pkg/scanners/terraform/parser/load_vars_test.go
@@ -3,27 +3,22 @@ package parser
 import (
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/aquasecurity/defsec/pkg/extrafs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func Test_TFVarsFile(t *testing.T) {
 	t.Run("tfvars file", func(t *testing.T) {
-		absPath, err := getAbsPath("testdata/tfvars/terraform.tfvars")
-		require.NoError(t, err)
-
-		vars, err := loadTFVars(extrafs.OSDir("/"), []string{absPath})
+		vars, err := loadTFVars(extrafs.OSDir("/"), []string{"testdata/tfvars/terraform.tfvars"})
 		require.NoError(t, err)
 		assert.Equal(t, "t2.large", vars["instance_type"].AsString())
 	})
 
 	t.Run("tfvars json file", func(t *testing.T) {
-		absPath, err := getAbsPath("testdata/tfvars/terraform.tfvars.json")
-		require.NoError(t, err)
-
-		vars, err := loadTFVars(extrafs.OSDir("/"), []string{absPath})
+		vars, err := loadTFVars(extrafs.OSDir("/"), []string{"testdata/tfvars/terraform.tfvars.json"})
 		require.NoError(t, err)
 		assert.Equal(t, "bar", vars["variable"].GetAttr("foo").GetAttr("default").AsString())
 		assert.Equal(t, "qux", vars["variable"].GetAttr("baz").AsString())

--- a/pkg/scanners/terraform/parser/load_vars_test.go
+++ b/pkg/scanners/terraform/parser/load_vars_test.go
@@ -3,35 +3,31 @@ package parser
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/aquasecurity/defsec/test/testutil"
-
+	"github.com/aquasecurity/defsec/pkg/extrafs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
-func Test_JsonVarsFile(t *testing.T) {
+func Test_TFVarsFile(t *testing.T) {
+	t.Run("tfvars file", func(t *testing.T) {
+		absPath, err := getAbsPath("testdata/tfvars/terraform.tfvars")
+		require.NoError(t, err)
 
-	fs := testutil.CreateFS(t, map[string]string{
-		"test.tfvars.json": `
-{
-	"variable": {
-		"foo": {
-			"default": "bar"
-		},
-		"baz": "qux"
-	},
-	"foo2": true,
-	"foo3": 3
-}
-`,
+		vars, err := loadTFVars(extrafs.OSDir("/"), []string{absPath})
+		require.NoError(t, err)
+		assert.Equal(t, "t2.large", vars["instance_type"].AsString())
 	})
 
-	vars, err := loadTFVars(fs, []string{"test.tfvars.json"})
-	require.NoError(t, err)
-	assert.Equal(t, "bar", vars["variable"].GetAttr("foo").GetAttr("default").AsString())
-	assert.Equal(t, "qux", vars["variable"].GetAttr("baz").AsString())
-	assert.Equal(t, true, vars["foo2"].True())
-	assert.Equal(t, true, vars["foo3"].Equals(cty.NumberIntVal(3)).True())
+	t.Run("tfvars json file", func(t *testing.T) {
+		absPath, err := getAbsPath("testdata/tfvars/terraform.tfvars.json")
+		require.NoError(t, err)
+
+		vars, err := loadTFVars(extrafs.OSDir("/"), []string{absPath})
+		require.NoError(t, err)
+		assert.Equal(t, "bar", vars["variable"].GetAttr("foo").GetAttr("default").AsString())
+		assert.Equal(t, "qux", vars["variable"].GetAttr("baz").AsString())
+		assert.Equal(t, true, vars["foo2"].True())
+		assert.Equal(t, true, vars["foo3"].Equals(cty.NumberIntVal(3)).True())
+	})
 }

--- a/pkg/scanners/terraform/parser/testdata/tfvars/terraform.tfvars
+++ b/pkg/scanners/terraform/parser/testdata/tfvars/terraform.tfvars
@@ -1,0 +1,1 @@
+instance_type = "t2.large"

--- a/pkg/scanners/terraform/parser/testdata/tfvars/terraform.tfvars.json
+++ b/pkg/scanners/terraform/parser/testdata/tfvars/terraform.tfvars.json
@@ -1,0 +1,10 @@
+{
+  "variable": {
+    "foo": {
+      "default": "bar"
+    },
+    "baz": "qux"
+  },
+  "foo2": true,
+  "foo3": 3
+}


### PR DESCRIPTION
Partially addresses: https://github.com/aquasecurity/trivy/issues/4006

Needs https://github.com/aquasecurity/trivy/pull/3991 to fully fix this.

Signed-off-by: Simar <simar@linux.com>