### PR TITLE
feat(scanner): Break out options for enabling libs and policies

### DIFF
--- a/cmd/defsec/aws.go
+++ b/cmd/defsec/aws.go
@@ -40,6 +40,7 @@ func scanAWS(stdout, stderr io.Writer) error {
 
 	opts := []options.ScannerOption{
 		options.ScannerWithEmbeddedPolicies(true),
+		options.ScannerWithEmbeddedLibraries(true),
 	}
 
 	if flagDebug {

--- a/cmd/defsec/fs.go
+++ b/cmd/defsec/fs.go
@@ -36,6 +36,7 @@ func scanFS(dir string, stdout, stderr io.Writer) error {
 
 	opts := []options.ScannerOption{
 		options.ScannerWithEmbeddedPolicies(true),
+		options.ScannerWithEmbeddedLibraries(true),
 	}
 
 	if flagDebug {

--- a/pkg/rego/load.go
+++ b/pkg/rego/load.go
@@ -93,7 +93,7 @@ func (s *Scanner) LoadEmbeddedLibraries() error {
 	return nil
 }
 
-func (s *Scanner) LoadPolicies(loadEmbedded bool, srcFS fs.FS, paths []string, readers []io.Reader) error {
+func (s *Scanner) LoadPolicies(enableEmbeddedLibraries, enableEmbeddedPolicies bool, srcFS fs.FS, paths []string, readers []io.Reader) error {
 
 	if s.policies == nil {
 		s.policies = make(map[string]*ast.Module)
@@ -104,7 +104,7 @@ func (s *Scanner) LoadPolicies(loadEmbedded bool, srcFS fs.FS, paths []string, r
 		srcFS = s.policyFS
 	}
 
-	if loadEmbedded {
+	if enableEmbeddedLibraries {
 		loadedLibs, errLoad := loadEmbeddedLibraries()
 		if errLoad != nil {
 			return fmt.Errorf("failed to load embedded rego libraries: %w", errLoad)
@@ -113,6 +113,9 @@ func (s *Scanner) LoadPolicies(loadEmbedded bool, srcFS fs.FS, paths []string, r
 			s.policies[name] = policy
 		}
 		s.debug.Log("Loaded %d embedded libraries.", len(loadedLibs))
+	}
+
+	if enableEmbeddedPolicies {
 		loaded, err := loadEmbeddedPolicies()
 		if err != nil {
 			return fmt.Errorf("failed to load embedded rego policies: %w", err)

--- a/pkg/rego/load.go
+++ b/pkg/rego/load.go
@@ -93,17 +93,7 @@ func (s *Scanner) LoadEmbeddedLibraries() error {
 	return nil
 }
 
-func (s *Scanner) LoadPolicies(enableEmbeddedLibraries, enableEmbeddedPolicies bool, srcFS fs.FS, paths []string, readers []io.Reader) error {
-
-	if s.policies == nil {
-		s.policies = make(map[string]*ast.Module)
-	}
-
-	if s.policyFS != nil {
-		s.debug.Log("Overriding filesystem for policies!")
-		srcFS = s.policyFS
-	}
-
+func (s *Scanner) loadEmbedded(enableEmbeddedLibraries, enableEmbeddedPolicies bool) error {
 	if enableEmbeddedLibraries {
 		loadedLibs, errLoad := loadEmbeddedLibraries()
 		if errLoad != nil {
@@ -124,6 +114,24 @@ func (s *Scanner) LoadPolicies(enableEmbeddedLibraries, enableEmbeddedPolicies b
 			s.policies[name] = policy
 		}
 		s.debug.Log("Loaded %d embedded policies.", len(loaded))
+	}
+
+	return nil
+}
+
+func (s *Scanner) LoadPolicies(enableEmbeddedLibraries, enableEmbeddedPolicies bool, srcFS fs.FS, paths []string, readers []io.Reader) error {
+
+	if s.policies == nil {
+		s.policies = make(map[string]*ast.Module)
+	}
+
+	if s.policyFS != nil {
+		s.debug.Log("Overriding filesystem for policies!")
+		srcFS = s.policyFS
+	}
+
+	if err := s.loadEmbedded(enableEmbeddedLibraries, enableEmbeddedPolicies); err != nil {
+		return err
 	}
 
 	var err error

--- a/pkg/rego/scanner.go
+++ b/pkg/rego/scanner.go
@@ -281,7 +281,7 @@ func (s *Scanner) ScanInput(ctx context.Context, inputs ...Input) (scan.Results,
 }
 
 func isPolicyWithSubtype(sourceType types.Source) bool {
-	for _, s := range []types.Source{types.SourceCloud, types.SourceDefsec, types.SourceKubernetes} { // TODO(simar): Add types.Kubernetes once all k8s policy have subtype
+	for _, s := range []types.Source{types.SourceCloud, types.SourceDefsec} { // TODO(simar): Add types.Kubernetes once all k8s policy have subtype
 		if sourceType == s {
 			return true
 		}

--- a/pkg/rego/scanner.go
+++ b/pkg/rego/scanner.go
@@ -45,6 +45,10 @@ type Scanner struct {
 	sourceType     types.Source
 }
 
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	// handled externally
+}
+
 func (s *Scanner) SetSpec(spec string) {
 	s.spec = spec
 }
@@ -58,6 +62,7 @@ func (s *Scanner) SetFrameworks(frameworks []framework.Framework) {
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
 	// handled externally
 }
+
 func (s *Scanner) trace(heading string, input interface{}) {
 	if s.traceWriter == nil {
 		return
@@ -276,7 +281,7 @@ func (s *Scanner) ScanInput(ctx context.Context, inputs ...Input) (scan.Results,
 }
 
 func isPolicyWithSubtype(sourceType types.Source) bool {
-	for _, s := range []types.Source{types.SourceCloud, types.SourceDefsec} { // TODO(simar): Add types.Kubernetes once all k8s policy have subtype
+	for _, s := range []types.Source{types.SourceCloud, types.SourceDefsec, types.SourceKubernetes} { // TODO(simar): Add types.Kubernetes once all k8s policy have subtype
 		if sourceType == s {
 			return true
 		}

--- a/pkg/rego/scanner_test.go
+++ b/pkg/rego/scanner_test.go
@@ -35,7 +35,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -70,7 +70,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"/policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"/policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -105,7 +105,7 @@ warn {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -137,7 +137,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -180,7 +180,7 @@ exception[ns] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -228,7 +228,7 @@ exception[ns] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -265,7 +265,7 @@ exception[rules] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -301,7 +301,7 @@ exception[rules] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -335,7 +335,7 @@ deny_evil {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -366,7 +366,7 @@ deny[msg] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -404,7 +404,7 @@ deny[res] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -446,7 +446,7 @@ deny[res] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -500,7 +500,7 @@ deny[res] {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -549,7 +549,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -583,7 +583,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -614,7 +614,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -649,7 +649,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON, options.ScannerWithTrace(traceBuffer))
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -683,7 +683,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON, options.ScannerWithPerResultTracing(true))
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -721,7 +721,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -754,7 +754,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -801,7 +801,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	require.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 
 	results, err := scanner.ScanInput(context.TODO(), Input{
@@ -839,7 +839,7 @@ deny {
 	scanner := NewScanner(types.SourceDockerfile)
 	assert.ErrorContains(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 		"undefined ref: input.evil",
 	)
 }
@@ -861,7 +861,7 @@ deny {
 	scanner := NewScanner(types.SourceDockerfile)
 	assert.NoError(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
 }
 
@@ -880,7 +880,7 @@ deny {
 	scanner := NewScanner(types.SourceJSON)
 	assert.ErrorContains(
 		t,
-		scanner.LoadPolicies(false, srcFS, []string{"policies"}, nil),
+		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 		"undefined ref: input.evil",
 	)
 }

--- a/pkg/scanners/azure/arm/scanner.go
+++ b/pkg/scanners/azure/arm/scanner.go
@@ -28,17 +28,18 @@ var _ scanners.FSScanner = (*Scanner)(nil)
 var _ options.ConfigurableScanner = (*Scanner)(nil)
 
 type Scanner struct {
-	scannerOptions []options.ScannerOption
-	parserOptions  []options.ParserOption
-	debug          debug.Logger
-	frameworks     []framework.Framework
-	skipRequired   bool
-	regoOnly       bool
-	loadEmbedded   bool
-	policyDirs     []string
-	policyReaders  []io.Reader
-	regoScanner    *rego.Scanner
-	spec           string
+	scannerOptions        []options.ScannerOption
+	parserOptions         []options.ParserOption
+	debug                 debug.Logger
+	frameworks            []framework.Framework
+	skipRequired          bool
+	regoOnly              bool
+	loadEmbeddedPolicies  bool
+	loadEmbeddedLibraries bool
+	policyDirs            []string
+	policyReaders         []io.Reader
+	regoScanner           *rego.Scanner
+	spec                  string
 	sync.Mutex
 }
 
@@ -87,8 +88,12 @@ func (s *Scanner) SetDataFilesystem(_ fs.FS) {
 	// handled by rego when option is passed on
 }
 
-func (s *Scanner) SetUseEmbeddedPolicies(loadEmbedded bool) {
-	s.loadEmbedded = loadEmbedded
+func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) SetFrameworks(frameworks []framework.Framework) {
@@ -108,7 +113,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) error {
 	}
 	regoScanner := rego.NewScanner(types.SourceCloud, s.scannerOptions...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/cloud/aws/scanner.go
+++ b/pkg/scanners/cloud/aws/scanner.go
@@ -34,21 +34,22 @@ var _ ConfigurableAWSScanner = (*Scanner)(nil)
 
 type Scanner struct {
 	sync.Mutex
-	regoScanner         *rego.Scanner
-	debug               debug.Logger
-	options             []options.ScannerOption
-	progressTracker     progress.Tracker
-	region              string
-	endpoint            string
-	services            []string
-	frameworks          []framework.Framework
-	spec                string
-	concurrencyStrategy concurrency.Strategy
-	policyDirs          []string
-	policyReaders       []io.Reader
-	policyFS            fs.FS
-	useEmbedded         bool
-	regoOnly            bool
+	regoScanner           *rego.Scanner
+	debug                 debug.Logger
+	options               []options.ScannerOption
+	progressTracker       progress.Tracker
+	region                string
+	endpoint              string
+	services              []string
+	frameworks            []framework.Framework
+	spec                  string
+	concurrencyStrategy   concurrency.Strategy
+	policyDirs            []string
+	policyReaders         []io.Reader
+	policyFS              fs.FS
+	loadEmbeddedPolicies  bool
+	loadEmbeddedLibraries bool
+	regoOnly              bool
 }
 
 func (s *Scanner) SetRegoOnly(value bool) {
@@ -92,7 +93,11 @@ func (s *Scanner) SetDataFilesystem(fs fs.FS) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.useEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) SetTraceWriter(writer io.Writer)   {}
@@ -226,7 +231,7 @@ func (s *Scanner) initRegoScanner() (*rego.Scanner, error) {
 
 	regoScanner := rego.NewScanner(types.SourceCloud, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.useEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/cloudformation/scanner.go
+++ b/pkg/scanners/cloudformation/scanner.go
@@ -28,17 +28,18 @@ import (
 var _ scanners.FSScanner = (*Scanner)(nil)
 
 type Scanner struct {
-	debug         debug.Logger
-	policyDirs    []string
-	policyReaders []io.Reader
-	parser        *parser.Parser
-	regoScanner   *rego.Scanner
-	skipRequired  bool
-	regoOnly      bool
-	loadEmbedded  bool
-	options       []options.ScannerOption
-	frameworks    []framework.Framework
-	spec          string
+	debug                 debug.Logger
+	policyDirs            []string
+	policyReaders         []io.Reader
+	parser                *parser.Parser
+	regoScanner           *rego.Scanner
+	skipRequired          bool
+	regoOnly              bool
+	loadEmbeddedPolicies  bool
+	loadEmbeddedLibraries bool
+	options               []options.ScannerOption
+	frameworks            []framework.Framework
+	spec                  string
 	sync.Mutex
 }
 
@@ -51,7 +52,11 @@ func (s *Scanner) SetSpec(spec string) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) SetRegoOnly(regoOnly bool) {
@@ -111,7 +116,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	regoScanner := rego.NewScanner(types.SourceCloud, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/dockerfile/scanner.go
+++ b/pkg/scanners/dockerfile/scanner.go
@@ -31,10 +31,11 @@ type Scanner struct {
 	regoScanner   *rego.Scanner
 	skipRequired  bool
 	options       []options.ScannerOption
-	loadEmbedded  bool
 	frameworks    []framework.Framework
 	spec          string
 	sync.Mutex
+	loadEmbeddedLibraries bool
+	loadEmbeddedPolicies  bool
 }
 
 func (s *Scanner) SetSpec(spec string) {
@@ -49,7 +50,11 @@ func (s *Scanner) SetFrameworks(frameworks []framework.Framework) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) Name() string {
@@ -155,7 +160,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 
 	regoScanner := rego.NewScanner(types.SourceDockerfile, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/helm/scanner.go
+++ b/pkg/scanners/helm/scanner.go
@@ -30,17 +30,18 @@ var _ scanners.FSScanner = (*Scanner)(nil)
 var _ options.ConfigurableScanner = (*Scanner)(nil)
 
 type Scanner struct {
-	policyDirs    []string
-	dataDirs      []string
-	debug         debug.Logger
-	options       []options.ScannerOption
-	parserOptions []options.ParserOption
-	policyReaders []io.Reader
-	loadEmbedded  bool
-	policyFS      fs.FS
-	skipRequired  bool
-	frameworks    []framework.Framework
-	spec          string
+	policyDirs            []string
+	dataDirs              []string
+	debug                 debug.Logger
+	options               []options.ScannerOption
+	parserOptions         []options.ParserOption
+	policyReaders         []io.Reader
+	loadEmbeddedLibraries bool
+	loadEmbeddedPolicies  bool
+	policyFS              fs.FS
+	skipRequired          bool
+	frameworks            []framework.Framework
+	spec                  string
 }
 
 func (s *Scanner) SetSpec(spec string) {
@@ -71,7 +72,11 @@ func (s *Scanner) AddParserOptions(options ...options.ParserOption) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) Name() string {
@@ -176,7 +181,7 @@ func (s *Scanner) getScanResults(path string, ctx context.Context, target fs.FS)
 	if s.policyFS != nil {
 		policyFS = s.policyFS
 	}
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, policyFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, policyFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, fmt.Errorf("policies load: %w", err)
 	}
 	for _, file := range chartFiles {

--- a/pkg/scanners/helm/test/scanner_test.go
+++ b/pkg/scanners/helm/test/scanner_test.go
@@ -35,7 +35,7 @@ func Test_helm_scanner_with_archive(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("Running test: %s", test.testName)
 
-		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true))
+		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true))
 
 		testTemp := t.TempDir()
 		testFileName := filepath.Join(testTemp, test.archiveName)
@@ -91,7 +91,7 @@ func Test_helm_scanner_with_missing_name_can_recover(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("Running test: %s", test.testName)
 
-		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true))
+		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true))
 
 		testTemp := t.TempDir()
 		testFileName := filepath.Join(testTemp, test.archiveName)
@@ -119,7 +119,7 @@ func Test_helm_scanner_with_dir(t *testing.T) {
 
 		t.Logf("Running test: %s", test.testName)
 
-		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true))
+		helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true))
 
 		testFs := os.DirFS(filepath.Join("testdata", test.chartName))
 		results, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
@@ -194,7 +194,7 @@ deny[res] {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Logf("Running test: %s", test.testName)
 
-			helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true),
+			helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true),
 				options.ScannerWithPolicyDirs("rules"),
 				options.ScannerWithPolicyNamespaces("user"))
 
@@ -259,7 +259,7 @@ func copyArchive(src, dst string) error {
 }
 
 func Test_helm_chart_with_templated_name(t *testing.T) {
-	helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true))
+	helmScanner := helm.New(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true))
 	testFs := os.DirFS(filepath.Join("testdata", "templated-name"))
 	_, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
 	require.NoError(t, err)

--- a/pkg/scanners/json/scanner.go
+++ b/pkg/scanners/json/scanner.go
@@ -34,7 +34,6 @@ type Scanner struct {
 	skipRequired  bool
 	options       []options.ScannerOption
 	sync.Mutex
-	loadEmbedded          bool
 	frameworks            []framework.Framework
 	spec                  string
 	loadEmbeddedPolicies  bool

--- a/pkg/scanners/json/scanner.go
+++ b/pkg/scanners/json/scanner.go
@@ -34,9 +34,11 @@ type Scanner struct {
 	skipRequired  bool
 	options       []options.ScannerOption
 	sync.Mutex
-	loadEmbedded bool
-	frameworks   []framework.Framework
-	spec         string
+	loadEmbedded          bool
+	frameworks            []framework.Framework
+	spec                  string
+	loadEmbeddedPolicies  bool
+	loadEmbeddedLibraries bool
 }
 
 func (s *Scanner) SetRegoOnly(bool) {
@@ -51,7 +53,11 @@ func (s *Scanner) SetSpec(spec string) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) SetPolicyReaders(readers []io.Reader) {
@@ -149,7 +155,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	regoScanner := rego.NewScanner(types.SourceJSON, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/kubernetes/scanner.go
+++ b/pkg/scanners/kubernetes/scanner.go
@@ -37,9 +37,10 @@ type Scanner struct {
 	parser        *parser.Parser
 	skipRequired  bool
 	sync.Mutex
-	loadEmbedded bool
-	frameworks   []framework.Framework
-	spec         string
+	loadEmbeddedPolicies  bool
+	frameworks            []framework.Framework
+	spec                  string
+	loadEmbeddedLibraries bool
 }
 
 func (s *Scanner) SetSpec(spec string) {
@@ -53,7 +54,11 @@ func (s *Scanner) SetFrameworks(frameworks []framework.Framework) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) SetPolicyReaders(readers []io.Reader) {
@@ -113,7 +118,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	regoScanner := rego.NewScanner(types.SourceKubernetes, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/kubernetes/scanner_test.go
+++ b/pkg/scanners/kubernetes/scanner_test.go
@@ -615,6 +615,7 @@ spec:
 	assert.Equal(t, "k8s.yaml", firstResult.Metadata().Range().GetFilename())
 }
 
+/*
 // TODO(simar): Uncomment once all k8s policies have subtype selector added
 func Test_checkPolicyIsApplicable(t *testing.T) {
 	srcFS := testutil.CreateFS(t, map[string]string{
@@ -734,3 +735,4 @@ spec:
 	failure := results.GetFailed()[0].Rule()
 	assert.Equal(t, "Process can elevate its own privileges", failure.Summary)
 }
+*/

--- a/pkg/scanners/kubernetes/scanner_test.go
+++ b/pkg/scanners/kubernetes/scanner_test.go
@@ -402,7 +402,10 @@ spec:
     name: hello2
 `
 
-	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true), options.ScannerWithEmbeddedLibraries(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(file))
+	results, err := NewScanner(
+		options.ScannerWithEmbeddedPolicies(true),
+		options.ScannerWithEmbeddedLibraries(true),
+		options.ScannerWithEmbeddedLibraries(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(file))
 	require.NoError(t, err)
 
 	assert.Greater(t, len(results.GetFailed()), 1)

--- a/pkg/scanners/kubernetes/scanner_test.go
+++ b/pkg/scanners/kubernetes/scanner_test.go
@@ -342,7 +342,7 @@ deny[res] {
 
 func Test_FileScan(t *testing.T) {
 
-	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(`
+	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true), options.ScannerWithEmbeddedLibraries(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(`
 apiVersion: v1
 kind: Pod
 metadata: 
@@ -360,7 +360,7 @@ spec:
 
 func Test_FileScan_WithSeparator(t *testing.T) {
 
-	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(`
+	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(`
 ---
 ---
 apiVersion: v1
@@ -402,7 +402,7 @@ spec:
     name: hello2
 `
 
-	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(file))
+	results, err := NewScanner(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true), options.ScannerWithEmbeddedLibraries(true)).ScanReader(context.TODO(), "k8s.yaml", strings.NewReader(file))
 	require.NoError(t, err)
 
 	assert.Greater(t, len(results.GetFailed()), 1)
@@ -541,7 +541,7 @@ func Test_FileScanExampleWithResultFunction(t *testing.T) {
 	results, err := NewScanner(
 		options.ScannerWithDebug(os.Stdout),
 		options.ScannerWithTrace(os.Stdout),
-		options.ScannerWithEmbeddedPolicies(true),
+		options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true),
 		options.ScannerWithPolicyReader(strings.NewReader(`package defsec
 
 import data.lib.kubernetes
@@ -616,7 +616,6 @@ spec:
 }
 
 // TODO(simar): Uncomment once all k8s policies have subtype selector added
-/*
 func Test_checkPolicyIsApplicable(t *testing.T) {
 	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/pod_policy.rego": `# METADATA
@@ -624,7 +623,7 @@ func Test_checkPolicyIsApplicable(t *testing.T) {
 # description: "A program inside the container can elevate its own privileges and run as root, which might give the program control over the container and node."
 # scope: package
 # schemas:
-# - input: schema["input"]
+# - input: schema["kubernetes"]
 # related_resources:
 # - https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 # custom:
@@ -673,7 +672,7 @@ deny[res] {
 # description: "ensure that default namespace should not be used"
 # scope: package
 # schemas:
-# - input: schema.input
+# - input: schema["kubernetes"]
 # related_resources:
 # - https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 # custom:
@@ -721,7 +720,8 @@ spec:
 	})
 
 	scanner := NewScanner(
-		options.ScannerWithEmbeddedPolicies(true),
+		//options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true),
+		options.ScannerWithEmbeddedLibraries(true),
 		options.ScannerWithPolicyDirs("policies/"),
 		options.ScannerWithPolicyFilesystem(srcFS),
 	)
@@ -734,4 +734,3 @@ spec:
 	failure := results.GetFailed()[0].Rule()
 	assert.Equal(t, "Process can elevate its own privileges", failure.Summary)
 }
-*/

--- a/pkg/scanners/options/scanner.go
+++ b/pkg/scanners/options/scanner.go
@@ -22,6 +22,7 @@ type ConfigurableScanner interface {
 	SetFrameworks(frameworks []framework.Framework)
 	SetSpec(spec string)
 	SetRegoOnly(regoOnly bool)
+	SetUseEmbeddedLibraries(bool)
 }
 
 type ScannerOption func(s ConfigurableScanner)
@@ -54,6 +55,12 @@ func ScannerWithDebug(w io.Writer) ScannerOption {
 func ScannerWithEmbeddedPolicies(embedded bool) ScannerOption {
 	return func(s ConfigurableScanner) {
 		s.SetUseEmbeddedPolicies(embedded)
+	}
+}
+
+func ScannerWithEmbeddedLibraries(enabled bool) ScannerOption {
+	return func(s ConfigurableScanner) {
+		s.SetUseEmbeddedLibraries(enabled)
 	}
 }
 

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/fs"
 	"path/filepath"
@@ -160,11 +159,6 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	regoScanner := rego.NewScanner(types.SourceCloud, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if s.enableEmbeddedLibraries { // TODO(simar7): Why is this here?
-		if err := regoScanner.LoadEmbeddedLibraries(); err != nil {
-			return nil, fmt.Errorf("failed to load embedded libraries: %w", err)
-		}
-	}
 
 	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -47,7 +47,6 @@ type Scanner struct {
 	debug                   debug.Logger
 	enableEmbeddedLibraries bool
 	sync.Mutex
-	loadEmbedded          bool
 	frameworks            []framework.Framework
 	spec                  string
 	loadEmbeddedLibraries bool

--- a/pkg/scanners/toml/scanner.go
+++ b/pkg/scanners/toml/scanner.go
@@ -30,9 +30,10 @@ type Scanner struct {
 	regoScanner   *rego.Scanner
 	skipRequired  bool
 	sync.Mutex
-	loadEmbedded bool
-	frameworks   []framework.Framework
-	spec         string
+	frameworks            []framework.Framework
+	spec                  string
+	loadEmbeddedPolicies  bool
+	loadEmbeddedLibraries bool
 }
 
 func (s *Scanner) SetRegoOnly(bool) {}
@@ -46,7 +47,11 @@ func (s *Scanner) SetSpec(spec string) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) Name() string {
@@ -141,7 +146,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	regoScanner := rego.NewScanner(types.SourceTOML, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/pkg/scanners/yaml/scanner.go
+++ b/pkg/scanners/yaml/scanner.go
@@ -30,9 +30,10 @@ type Scanner struct {
 	regoScanner   *rego.Scanner
 	skipRequired  bool
 	sync.Mutex
-	loadEmbedded bool
-	frameworks   []framework.Framework
-	spec         string
+	frameworks            []framework.Framework
+	spec                  string
+	loadEmbeddedLibraries bool
+	loadEmbeddedPolicies  bool
 }
 
 func (s *Scanner) SetRegoOnly(bool) {}
@@ -46,7 +47,11 @@ func (s *Scanner) SetSpec(spec string) {
 }
 
 func (s *Scanner) SetUseEmbeddedPolicies(b bool) {
-	s.loadEmbedded = b
+	s.loadEmbeddedPolicies = b
+}
+
+func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
+	s.loadEmbeddedLibraries = b
 }
 
 func (s *Scanner) Name() string {
@@ -142,7 +147,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	regoScanner := rego.NewScanner(types.SourceYAML, s.options...)
 	regoScanner.SetParentDebugLogger(s.debug)
-	if err := regoScanner.LoadPolicies(s.loadEmbedded, srcFS, s.policyDirs, s.policyReaders); err != nil {
+	if err := regoScanner.LoadPolicies(s.loadEmbeddedLibraries, s.loadEmbeddedPolicies, srcFS, s.policyDirs, s.policyReaders); err != nil {
 		return nil, err
 	}
 	s.regoScanner = regoScanner

--- a/test/docker_test.go
+++ b/test/docker_test.go
@@ -79,7 +79,7 @@ func Test_Docker_RegoPoliciesEmbedded(t *testing.T) {
 	entries, err := os.ReadDir("./testdata/dockerfile")
 	require.NoError(t, err)
 
-	scanner := dockerfile.NewScanner(options.ScannerWithEmbeddedPolicies(true))
+	scanner := dockerfile.NewScanner(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true))
 	srcFS := os.DirFS("../")
 
 	results, err := scanner.ScanFS(context.TODO(), srcFS, "test/testdata/dockerfile")

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -26,6 +26,7 @@ func Test_Kubernetes_RegoPoliciesFromDisk(t *testing.T) {
 	scanner := kubernetes.NewScanner(
 		options.ScannerWithPerResultTracing(true),
 		options.ScannerWithEmbeddedPolicies(true),
+		options.ScannerWithEmbeddedLibraries(true),
 	)
 
 	srcFS := os.DirFS("../")
@@ -83,7 +84,7 @@ func Test_Kubernetes_RegoPoliciesEmbedded(t *testing.T) {
 	entries, err := os.ReadDir("./testdata/kubernetes")
 	require.NoError(t, err)
 
-	scanner := kubernetes.NewScanner(options.ScannerWithEmbeddedPolicies(true))
+	scanner := kubernetes.NewScanner(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true), options.ScannerWithEmbeddedLibraries(true))
 
 	srcFS := os.DirFS("../")
 


### PR DESCRIPTION
This adds the `SetUseEmbeddedLibraries` option for scanners. It is needed in cases where we only want to load libraries but not policies. 

Signed-off-by: Simar <simar@linux.com>