### PR TITLE
feat: GCP compute instance rule 'enable secure boot'

### DIFF
--- a/avd_docs/google/compute/AVD-GCP-0067/Terraform.md
+++ b/avd_docs/google/compute/AVD-GCP-0067/Terraform.md
@@ -1,0 +1,32 @@
+
+Enable Shielded VM secure boot
+
+```hcl
+ resource "google_compute_instance" "good_example" {
+   name         = "test"
+   machine_type = "e2-medium"
+   zone         = "us-central1-a"
+ 
+   tags = ["foo", "bar"]
+ 
+   boot_disk {
+     initialize_params {
+       image = "debian-cloud/debian-9"
+     }
+   }
+ 
+   // Local SSD disk
+   scratch_disk {
+     interface = "SCSI"
+   }
+ 
+   shielded_instance_config {
+     enable_secure_boot = true
+   }
+ }
+ 
+```
+
+#### Remediation Links
+ - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#enable_secure_boot
+

--- a/avd_docs/google/compute/AVD-GCP-0067/docs.md
+++ b/avd_docs/google/compute/AVD-GCP-0067/docs.md
@@ -1,0 +1,13 @@
+
+Secure boot helps ensure that the system only runs authentic software.
+
+### Impact
+Unable to verify digital signature of boot components, and unable to stop the boot process if verificaiton fails.
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://cloud.google.com/security/shielded-cloud/shielded-vm#secure-boot
+
+

--- a/rules/cloud/policies/google/compute/enable_shielded_vm_sb.go
+++ b/rules/cloud/policies/google/compute/enable_shielded_vm_sb.go
@@ -1,0 +1,48 @@
+package compute
+
+import (
+	"github.com/aquasecurity/defsec/internal/rules"
+	"github.com/aquasecurity/defsec/pkg/providers"
+	"github.com/aquasecurity/defsec/pkg/scan"
+	"github.com/aquasecurity/defsec/pkg/severity"
+	"github.com/aquasecurity/defsec/pkg/state"
+)
+
+var CheckEnableShieldedVMSecureBoot = rules.Register(
+	scan.Rule{
+		AVDID:       "AVD-GCP-0067",
+		Provider:    providers.GoogleProvider,
+		Service:     "compute",
+		ShortCode:   "enable-shielded-vm-sb",
+		Summary:     "Instances should have Shielded VM secure boot enabled",
+		Impact:      "Unable to verify digital signature of boot components, and unable to stop the boot process if verificaiton fails.",
+		Resolution:  "Enable Shielded VM secure boot",
+		Explanation: `Secure boot helps ensure that the system only runs authentic software.`,
+		Links: []string{
+			"https://cloud.google.com/security/shielded-cloud/shielded-vm#secure-boot",
+		},
+		Terraform: &scan.EngineMetadata{
+			GoodExamples:        terraformEnableShieldedVmSbGoodExamples,
+			BadExamples:         terraformEnableShieldedVmSbBadExamples,
+			Links:               terraformEnableShieldedVmSbLinks,
+			RemediationMarkdown: terraformEnableShieldedVmSbRemediationMarkdown,
+		},
+		Severity: severity.Medium,
+	},
+	func(s *state.State) (results scan.Results) {
+		for _, instance := range s.Google.Compute.Instances {
+			if instance.Metadata.IsUnmanaged() {
+				continue
+			}
+			if instance.ShieldedVM.SecureBootEnabled.IsFalse() {
+				results.Add(
+					"Instance does not have shielded VM secure boot enabled.",
+					instance.ShieldedVM.SecureBootEnabled,
+				)
+			} else {
+				results.AddPassed(&instance)
+			}
+		}
+		return
+	},
+)

--- a/rules/cloud/policies/google/compute/enable_shielded_vm_sb.tf.go
+++ b/rules/cloud/policies/google/compute/enable_shielded_vm_sb.tf.go
@@ -1,0 +1,61 @@
+package compute
+
+var terraformEnableShieldedVmSbGoodExamples = []string{
+	`
+ resource "google_compute_instance" "good_example" {
+   name         = "test"
+   machine_type = "e2-medium"
+   zone         = "us-central1-a"
+ 
+   tags = ["foo", "bar"]
+ 
+   boot_disk {
+     initialize_params {
+       image = "debian-cloud/debian-9"
+     }
+   }
+ 
+   // Local SSD disk
+   scratch_disk {
+     interface = "SCSI"
+   }
+ 
+   shielded_instance_config {
+     enable_secure_boot = true
+   }
+ }
+ `,
+}
+
+var terraformEnableShieldedVmSbBadExamples = []string{
+	`
+ resource "google_compute_instance" "bad_example" {
+   name         = "test"
+   machine_type = "e2-medium"
+   zone         = "us-central1-a"
+ 
+   tags = ["foo", "bar"]
+ 
+   boot_disk {
+     initialize_params {
+       image = "debian-cloud/debian-9"
+     }
+   }
+ 
+   // Local SSD disk
+   scratch_disk {
+     interface = "SCSI"
+   }
+ 
+   shielded_instance_config {
+     enable_secure_boot = false
+   }
+ }
+ `,
+}
+
+var terraformEnableShieldedVmSbLinks = []string{
+	`https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#enable_secure_boot`,
+}
+
+var terraformEnableShieldedVmSbRemediationMarkdown = ``

--- a/rules/cloud/policies/google/compute/enable_shielded_vm_sb_test.go
+++ b/rules/cloud/policies/google/compute/enable_shielded_vm_sb_test.go
@@ -1,0 +1,71 @@
+package compute
+
+import (
+	"testing"
+
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/state"
+
+	"github.com/aquasecurity/defsec/pkg/providers/google/compute"
+	"github.com/aquasecurity/defsec/pkg/scan"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckEnableShieldedVMSecureBoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    compute.Compute
+		expected bool
+	}{
+		{
+			name: "Instance shielded VM secure boot disabled",
+			input: compute.Compute{
+				Instances: []compute.Instance{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						ShieldedVM: compute.ShieldedVMConfig{
+							Metadata:          defsecTypes.NewTestMetadata(),
+							SecureBootEnabled: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Instance shielded VM secure boot enabled",
+			input: compute.Compute{
+				Instances: []compute.Instance{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						ShieldedVM: compute.ShieldedVMConfig{
+							Metadata:          defsecTypes.NewTestMetadata(),
+							SecureBootEnabled: defsecTypes.Bool(true, defsecTypes.NewTestMetadata()),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var testState state.State
+			testState.Google.Compute = test.input
+			results := CheckEnableShieldedVMSecureBoot.Evaluate(&testState)
+			var found bool
+			for _, result := range results {
+				if result.Status() == scan.StatusFailed && result.Rule().LongID() == CheckEnableShieldedVMSecureBoot.Rule().LongID() {
+					found = true
+				}
+			}
+			if test.expected {
+				assert.True(t, found, "Rule should have been found")
+			} else {
+				assert.False(t, found, "Rule should not have been found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding GCP rule for enable secure boot within shielded VM:
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#enable_secure_boot