### PR TITLE
fix: kubelet policies --read-only-port and --anonymous-auth

### DIFF
--- a/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument.rego
@@ -28,13 +28,6 @@ validate_kubelet_anonymous_auth_set(sp) := {"kubeletAnonymousAuthArgumentSet": v
 	count(violation) > 0
 }
 
-validate_kubelet_anonymous_auth_set(sp) := {"kubeletAnonymousAuthArgumentSet": anonymous_auth} {
-	sp.kind == "NodeInfo"
-	sp.type == types[_]
-	count(sp.info.kubeletAnonymousAuthArgumentSet.values) == 0
-	anonymous_auth = {}
-}
-
 deny[res] {
 	output := validate_kubelet_anonymous_auth_set(input)
 	msg := "Ensure that the --anonymous-auth argument is set to false"

--- a/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument_test.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_anonymous_auth_argument_test.rego
@@ -19,7 +19,7 @@ test_validate_kubelet_anonymous_auth_not_set {
 		"info": {"kubeletAnonymousAuthArgumentSet": {"values": []}},
 	}
 
-	count(r) == 1
+	count(r) == 0
 }
 
 test_validate_kubelet_anonymous_auth_set_false {

--- a/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_read_only_port_argument.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_read_only_port_argument.rego
@@ -28,13 +28,6 @@ validate_kubelet_read_only_set(sp) := {"kubeletReadOnlyPortArgumentSet": violati
 	count(violation) > 0
 }
 
-validate_kubelet_read_only_set(sp) := {"kubeletReadOnlyPortArgumentSet": read_only} {
-	sp.kind == "NodeInfo"
-	sp.type == types[_]
-	count(sp.info.kubeletReadOnlyPortArgumentSet.values) == 0
-	read_only = {}
-}
-
 deny[res] {
 	output := validate_kubelet_read_only_set(input)
 	msg := "Verify that the --read-only-port argument is set to 0"

--- a/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_read_only_port_argument_test.rego
+++ b/rules/kubernetes/policies/cisbenchmarks/kubelet/kubelet_read_only_port_argument_test.rego
@@ -30,5 +30,5 @@ test_validate_read_only_argument_not_set {
 		"info": {"kubeletReadOnlyPortArgumentSet": {"values": []}},
 	}
 
-	count(r) == 1
+	count(r) == 0
 }


### PR DESCRIPTION
Related https://github.com/aquasecurity/trivy-operator/issues/1181