### PR TITLE
Support checking for the last user as 'root' with a group specified, …

### DIFF
--- a/rules/docker/policies/root_user.rego
+++ b/rules/docker/policies/root_user.rego
@@ -36,7 +36,15 @@ fail_user_count {
 fail_last_user_root[lastUser] {
 	users := [user | user := docker.user[_]; true]
 	lastUser := users[count(users) - 1]
-	lastUser.Value[0] == "root"
+	regex.match("^root(:.+){0,1}$", lastUser.Value[0])
+}
+
+# fail_last_user_root is true if the last USER command
+# value is "0"
+fail_last_user_root[lastUser] {
+	users := [user | user := docker.user[_]; true]
+	lastUser := users[count(users) - 1]
+	regex.match("^0(:.+){0,1}$", lastUser.Value[0])
 }
 
 deny[res] {

--- a/rules/docker/policies/root_user_test.rego
+++ b/rules/docker/policies/root_user_test.rego
@@ -117,6 +117,75 @@ test_last_root_case_2 {
 	startswith(r[_].msg, "Last USER command in Dockerfile should not be 'root'")
 }
 
+test_last_root_with_group_denied {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [
+			{
+				"Cmd": "user",
+				"Value": ["user1"],
+				"StartLine": 1,
+				"Stage": 1,
+			},
+			{
+				"Cmd": "user",
+				"Value": ["root:root"],
+				"StartLine": 2,
+				"Stage": 1,
+			},
+		],
+	}]}
+
+	count(r) > 0
+	startswith(r[_].msg, "Last USER command in Dockerfile should not be 'root'")
+}
+
+test_last_root_as_uid_number_denied {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [
+			{
+				"Cmd": "user",
+				"Value": ["user1"],
+				"StartLine": 1,
+				"Stage": 1,
+			},
+			{
+				"Cmd": "user",
+				"Value": ["0"],
+				"StartLine": 2,
+				"Stage": 1,
+			},
+		],
+	}]}
+
+	count(r) > 0
+	startswith(r[_].msg, "Last USER command in Dockerfile should not be 'root'")
+}
+
+test_last_root_as_uid_number_with_group_denied {
+	r := deny with input as {"Stages": [{
+		"Name": "alpine:3.13",
+		"Commands": [
+			{
+				"Cmd": "user",
+				"Value": ["user1"],
+				"StartLine": 1,
+				"Stage": 1,
+			},
+			{
+				"Cmd": "user",
+				"Value": ["0:0"],
+				"StartLine": 2,
+				"Stage": 1,
+			},
+		],
+	}]}
+
+	count(r) > 0
+	startswith(r[_].msg, "Last USER command in Dockerfile should not be 'root'")
+}
+
 test_empty_user_denied {
 	r := deny with input as {"Stages": [{
 		"Name": "alpine:3.13",


### PR DESCRIPTION
…and checking for a root user specified as UID 0, with or without a group name or GID number specified