### PR TITLE
fix(rego): Use correct `id` for AVD-KSV-01010

### DIFF
--- a/rules/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego
+++ b/rules/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego
@@ -5,7 +5,7 @@
 # schemas:
 # - input: schema["kubernetes"]
 # custom:
-#   id: AVD-KSV-0110
+#   id: AVD-KSV-01010
 #   avd_id: AVD-KSV-01010
 #   severity: HIGH
 #   short_code: configMap_with_sensitive


### PR DESCRIPTION
Discovered this when trivy gave us a false positive on a keyname in one of our configmaps.
In the error message, `avd_id` is not used, rather `id` is used to create the URL to AVD.
So for AVD-KSV-01010, the generated url is `https://avd.aquasec.com/misconfig/avd-ksv-0110`.

Also, I checked the report uploaded to Github Advanced Security. `id` is also referenced there it seems, like this;
```markdown
Artifact: configmap.yaml
Type: kubernetes
Vulnerability AVD-KSV-0110
Severity: HIGH
Message: ConfigMap 'foo-config' in 'default' namespace stores sensitive contents in key(s) or value(s) '{"key"}'
Link: [AVD-KSV-0110](https://avd.aquasec.com/misconfig/avd-ksv-0110)

Trivy
```

So I guess this should fix that one as well, as I can't find any other combinations of AVD-KSV-0110 and AVD-KSV-01010 under the aquasecurity organization.

Minimal repro for observing the bug with incorrect ID;
```bash
tee -a configmap.yaml <<EOF
apiVersion: v1
kind: ConfigMap
metadata:
  name: foo-config
data:
  key: "bar"
EOF

trivy config configmap.yaml
```

Tested using Trivy 0.42.1