### PR TITLE
support import block for tf 1.5.0+

### DIFF
--- a/pkg/scanners/terraform/parser/evaluator.go
+++ b/pkg/scanners/terraform/parser/evaluator.go
@@ -385,7 +385,7 @@ func (e *evaluator) getValuesByBlockType(blockType string) cty.Value {
 				continue
 			}
 			values[b.Label()] = val
-		case "locals", "moved":
+		case "locals", "moved", "import":
 			for key, val := range b.Values().AsValueMap() {
 				values[key] = val
 			}

--- a/pkg/scanners/terraform/parser/parser_test.go
+++ b/pkg/scanners/terraform/parser/parser_test.go
@@ -38,6 +38,10 @@ moved {
 
 }
 
+import {
+
+}
+
 resource "cats_cat" "mittens" {
 	name = "mittens"
 	special = true
@@ -45,7 +49,7 @@ resource "cats_cat" "mittens" {
 
 resource "cats_kitten" "the-great-destroyer" {
 	name = "the great destroyer"
-    parent = cats_cat.mittens.name
+	parent = cats_cat.mittens.name
 }
 
 data "cats_cat" "the-cats-mother" {

--- a/pkg/scanners/terraform/parser/parser_test.go
+++ b/pkg/scanners/terraform/parser/parser_test.go
@@ -39,7 +39,8 @@ moved {
 }
 
 import {
-
+  to = cats_cat.mittens
+  id = "mittens"
 }
 
 resource "cats_cat" "mittens" {
@@ -108,6 +109,13 @@ data "cats_cat" "the-cats-mother" {
 	assert.Equal(t, "cats_kitten", resourceBlocks[1].TypeLabel())
 	assert.Equal(t, "the great destroyer", resourceBlocks[1].GetAttribute("name").Value().AsString())
 	assert.Equal(t, "mittens", resourceBlocks[1].GetAttribute("parent").Value().AsString())
+
+	// import
+	importBlocks := blocks.OfType("import")
+
+	assert.Equal(t, "import", importBlocks[0].Type())
+	require.NotNil(t, importBlocks[0].GetAttribute("to"))
+	assert.Equal(t, "mittens", importBlocks[0].GetAttribute("id").Value().AsString())
 
 	// data
 	dataBlocks := blocks.OfType("data")

--- a/pkg/terraform/schema.go
+++ b/pkg/terraform/schema.go
@@ -41,5 +41,8 @@ var Schema = &hcl.BodySchema{
 		{
 			Type: "moved",
 		},
+		{
+			Type: "import",
+		},
 	},
 }

--- a/pkg/terraform/type.go
+++ b/pkg/terraform/type.go
@@ -33,6 +33,10 @@ var TypeVariable = Type{
 	refName: "var",
 }
 
+var TypeImport = Type{
+	name: "import",
+}
+
 var TypeLocal = Type{
 	name:    "locals",
 	refName: "local",
@@ -60,6 +64,7 @@ var TypeTerraform = Type{
 
 var ValidTypes = []Type{
 	TypeData,
+	TypeImport,
 	TypeLocal,
 	TypeModule,
 	TypeMoved,


### PR DESCRIPTION
docs:
- https://github.com/hashicorp/terraform/blob/v1.5/CHANGELOG.md#150-june-12-2023
- https://developer.hashicorp.com/terraform/language/import

New `import` block was added from Terraform 1.5.0
I added type support in a form similar to `moved` block.