### PR TITLE
support check block for tf 1.5.0+

### DIFF
--- a/pkg/scanners/terraform/parser/evaluator.go
+++ b/pkg/scanners/terraform/parser/evaluator.go
@@ -389,7 +389,7 @@ func (e *evaluator) getValuesByBlockType(blockType string) cty.Value {
 			for key, val := range b.Values().AsValueMap() {
 				values[key] = val
 			}
-		case "provider", "module":
+		case "provider", "module", "check":
 			if b.Label() == "" {
 				continue
 			}

--- a/pkg/scanners/terraform/parser/parser_test.go
+++ b/pkg/scanners/terraform/parser/parser_test.go
@@ -57,6 +57,17 @@ data "cats_cat" "the-cats-mother" {
 	name = local.proxy
 }
 
+check "cats_mittens_is_special" {
+  data "cats_cat" "mittens" {
+    name = "mittens"
+  }
+
+  assert {
+    condition = data.cats_cat.mittens.special == true
+    error_message = "${data.cats_cat.mittens.name} must be special"
+  }
+}
+
 `,
 	})
 
@@ -127,6 +138,17 @@ data "cats_cat" "the-cats-mother" {
 	assert.Equal(t, "the-cats-mother", dataBlocks[0].NameLabel())
 
 	assert.Equal(t, "boots", dataBlocks[0].GetAttribute("name").Value().AsString())
+
+	// check
+	checkBlocks := blocks.OfType("check")
+	require.Len(t, checkBlocks, 1)
+	require.Len(t, checkBlocks[0].Labels(), 1)
+
+	assert.Equal(t, "check", checkBlocks[0].Type())
+	assert.Equal(t, "cats_mittens_is_special", checkBlocks[0].TypeLabel())
+
+	require.NotNil(t, checkBlocks[0].GetBlock("data"))
+	require.NotNil(t, checkBlocks[0].GetBlock("assert"))
 }
 
 func Test_Modules(t *testing.T) {

--- a/pkg/terraform/schema.go
+++ b/pkg/terraform/schema.go
@@ -31,6 +31,10 @@ var Schema = &hcl.BodySchema{
 			LabelNames: []string{"name"},
 		},
 		{
+			Type:       "check",
+			LabelNames: []string{"name"},
+		},
+		{
 			Type:       "resource",
 			LabelNames: []string{"type", "name"},
 		},

--- a/pkg/terraform/type.go
+++ b/pkg/terraform/type.go
@@ -19,6 +19,10 @@ func (t Type) ShortName() string {
 	return t.name
 }
 
+var TypeCheck = Type{
+	name: "check",
+}
+
 var TypeData = Type{
 	name: "data",
 }
@@ -63,6 +67,7 @@ var TypeTerraform = Type{
 }
 
 var ValidTypes = []Type{
+	TypeCheck,
 	TypeData,
 	TypeImport,
 	TypeLocal,


### PR DESCRIPTION
As of Terraform 1.5, support has been added for `check` blocks.

https://github.com/hashicorp/terraform/blob/v1.5/CHANGELOG.md#150-june-12-2023
https://developer.hashicorp.com/terraform/language/checks

I'm adding `check` type support in a form similar to `import` block.