### PR TITLE
Support define api-versions for helm scanner

### DIFF
--- a/pkg/scanners/helm/options.go
+++ b/pkg/scanners/helm/options.go
@@ -41,3 +41,11 @@ func ScannerWithStringValues(values ...string) options.ScannerOption {
 		}
 	}
 }
+
+func ScannerWithAPIVersions(values ...string) options.ScannerOption {
+	return func(s options.ConfigurableScanner) {
+		if helmScanner, ok := s.(ConfigurableHelmScanner); ok {
+			helmScanner.AddParserOptions(parser.OptionWithAPIVersions(values...))
+		}
+	}
+}

--- a/pkg/scanners/helm/parser/option.go
+++ b/pkg/scanners/helm/parser/option.go
@@ -8,6 +8,7 @@ type ConfigurableHelmParser interface {
 	SetValues(...string)
 	SetFileValues(...string)
 	SetStringValues(...string)
+	SetAPIVersions(...string)
 }
 
 func OptionWithValuesFile(paths ...string) options.ParserOption {
@@ -38,6 +39,14 @@ func OptionWithStringValues(values ...string) options.ParserOption {
 	return func(p options.ConfigurableParser) {
 		if helmParser, ok := p.(ConfigurableHelmParser); ok {
 			helmParser.SetValues(values...)
+		}
+	}
+}
+
+func OptionWithAPIVersions(values ...string) options.ParserOption {
+	return func(p options.ConfigurableParser) {
+		if helmParser, ok := p.(ConfigurableHelmParser); ok {
+			helmParser.SetAPIVersions(values...)
 		}
 	}
 }

--- a/pkg/scanners/helm/parser/parser.go
+++ b/pkg/scanners/helm/parser/parser.go
@@ -41,6 +41,7 @@ type Parser struct {
 	values       []string
 	fileValues   []string
 	stringValues []string
+	apiVersions  []string
 }
 
 type ChartFile struct {
@@ -72,6 +73,10 @@ func (p *Parser) SetStringValues(values ...string) {
 	p.stringValues = values
 }
 
+func (p *Parser) SetAPIVersions(values ...string) {
+	p.apiVersions = values
+}
+
 func New(path string, options ...options.ParserOption) *Parser {
 
 	client := action.NewInstall(&action.Configuration{})
@@ -87,6 +92,11 @@ func New(path string, options ...options.ParserOption) *Parser {
 	for _, option := range options {
 		option(p)
 	}
+
+	if p.apiVersions != nil {
+		p.helmClient.APIVersions = p.apiVersions
+	}
+
 	return p
 }
 
@@ -212,7 +222,6 @@ func (p *Parser) RenderedChartFiles() ([]ChartFile, error) {
 }
 
 func (p *Parser) getRelease(chart *chart.Chart) (*release.Release, error) {
-
 	opts := &ValueOptions{
 		ValueFiles:   p.valuesFiles,
 		Values:       p.values,

--- a/pkg/scanners/helm/test/option_test.go
+++ b/pkg/scanners/helm/test/option_test.go
@@ -115,3 +115,52 @@ func Test_helm_parser_with_options_with_set_value(t *testing.T) {
 		})
 	}
 }
+
+func Test_helm_parser_with_options_with_api_versions(t *testing.T) {
+
+	tests := []struct {
+		testName    string
+		chartName   string
+		apiVersions []string
+	}{
+		{
+			testName:    "Parsing directory 'with-api-version'",
+			chartName:   "with-api-version",
+			apiVersions: []string{"policy/v1/PodDisruptionBudget"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			chartName := test.chartName
+
+			t.Logf("Running test: %s", test.testName)
+
+			var opts []options.ParserOption
+
+			if len(test.apiVersions) > 0 {
+				opts = append(opts, parser.OptionWithAPIVersions(test.apiVersions...))
+			}
+
+			helmParser := parser.New(chartName, opts...)
+			err := helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
+			require.NoError(t, err)
+			manifests, err := helmParser.RenderedChartFiles()
+			require.NoError(t, err)
+
+			assert.Len(t, manifests, 1)
+
+			for _, manifest := range manifests {
+				expectedPath := filepath.Join("testdata", "expected", "options", chartName, manifest.TemplateFilePath)
+
+				expectedContent, err := os.ReadFile(expectedPath)
+				require.NoError(t, err)
+
+				cleanExpected := strings.TrimSpace(strings.ReplaceAll(string(expectedContent), "\r\n", "\n"))
+				cleanActual := strings.TrimSpace(strings.ReplaceAll(manifest.ManifestContent, "\r\n", "\n"))
+
+				assert.Equal(t, cleanExpected, cleanActual)
+			}
+		})
+	}
+}

--- a/pkg/scanners/helm/test/testdata/expected/options/with-api-version/templates/pdb.yaml
+++ b/pkg/scanners/helm/test/testdata/expected/options/with-api-version/templates/pdb.yaml
@@ -1,0 +1,17 @@
+# Source: with-api-version/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: with-api-version
+  labels:
+    helm.sh/chart: with-api-version-0.1.0
+    app.kubernetes.io/name: with-api-version
+    app.kubernetes.io/instance: with-api-version
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: with-api-version
+      app.kubernetes.io/instance: with-api-version
+  maxUnavailable: 0

--- a/pkg/scanners/helm/test/testdata/with-api-version/.helmignore
+++ b/pkg/scanners/helm/test/testdata/with-api-version/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/scanners/helm/test/testdata/with-api-version/Chart.yaml
+++ b/pkg/scanners/helm/test/testdata/with-api-version/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: with-api-version
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/pkg/scanners/helm/test/testdata/with-api-version/templates/_helpers.tpl
+++ b/pkg/scanners/helm/test/testdata/with-api-version/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "with-api-version.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "with-api-version.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "with-api-version.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "with-api-version.labels" -}}
+helm.sh/chart: {{ include "with-api-version.chart" . }}
+{{ include "with-api-version.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "with-api-version.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "with-api-version.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "with-api-version.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "with-api-version.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/pkg/scanners/helm/test/testdata/with-api-version/templates/pdb.yaml
+++ b/pkg/scanners/helm/test/testdata/with-api-version/templates/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: {{ $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" | ternary "policy/v1" "policy/v1beta1" }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "with-api-version.fullname" . }}
+  labels:
+    {{- include "with-api-version.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "with-api-version.selectorLabels" . | nindent 6 }}
+  maxUnavailable: 0


### PR DESCRIPTION
This PR add an function is pass `--api-versions` to the helm command.

This resolves an issue, where trivy reports a misconfiguration because of deprecated APIVersions, but the helm chart is using `Capabilities.APIVersions.Has` to validate if the newer API Version is available. 


```yaml
apiVersion: {{ $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" | ternary "policy/v1" "policy/v1beta1" }}
kind: PodDisruptionBudget
```

`Capabilities.APIVersions.Has` does not work well, since defsec is running helm with `--dry-run --client`