### PR TITLE
perf(detection): use strings.Builder

### DIFF
--- a/pkg/scanners/azure/arm/parser/armjson/parse_comment.go
+++ b/pkg/scanners/azure/arm/parser/armjson/parse_comment.go
@@ -1,6 +1,10 @@
 package armjson
 
-import "github.com/aquasecurity/defsec/pkg/types"
+import (
+	"strings"
+
+	"github.com/aquasecurity/defsec/pkg/types"
+)
 
 func (p *parser) parseComment(parentMetadata *types.Metadata) (Node, error) {
 
@@ -32,7 +36,7 @@ func (p *parser) parseLineComment(parentMetadata *types.Metadata) (Node, error) 
 
 	n, _ := p.newNode(KindComment, parentMetadata)
 
-	var comment string
+	var sb strings.Builder
 	for {
 		c, err := p.next()
 		if err != nil {
@@ -43,10 +47,10 @@ func (p *parser) parseLineComment(parentMetadata *types.Metadata) (Node, error) 
 			p.position.Line++
 			break
 		}
-		comment += string(c)
+		sb.WriteRune(c)
 	}
 
-	n.raw = comment
+	n.raw = sb.String()
 	n.end = p.position
 
 	if err := p.parseWhitespace(); err != nil {
@@ -59,7 +63,7 @@ func (p *parser) parseBlockComment(parentMetadata *types.Metadata) (Node, error)
 
 	n, _ := p.newNode(KindComment, parentMetadata)
 
-	var comment string
+	var sb strings.Builder
 
 	for {
 		c, err := p.next()
@@ -74,17 +78,17 @@ func (p *parser) parseBlockComment(parentMetadata *types.Metadata) (Node, error)
 			if c == '/' {
 				break
 			}
-			comment += "*"
+			sb.WriteRune('*')
 		} else {
 			if c == '\n' {
 				p.position.Column = 1
 				p.position.Line++
 			}
-			comment += string(c)
+			sb.WriteRune(c)
 		}
 	}
 
-	n.raw = comment
+	n.raw = sb.String()
 
 	if err := p.parseWhitespace(); err != nil {
 		return nil, err

--- a/pkg/scanners/azure/arm/parser/armjson/parse_number.go
+++ b/pkg/scanners/azure/arm/parser/armjson/parse_number.go
@@ -3,6 +3,7 @@ package armjson
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/aquasecurity/defsec/pkg/types"
 )
@@ -64,21 +65,21 @@ func (p *parser) parseIntegral() (string, error) {
 		return "0", nil
 	}
 
-	var str string
+	var sb strings.Builder
 	if r < '1' || r > '9' {
 		return "", p.makeError("invalid number")
 	}
-	str += string(r)
+	sb.WriteRune(r)
 
 	for {
 		r, err := p.next()
 		if err != nil {
-			return str, nil
+			return sb.String(), nil
 		}
 		if r < '0' || r > '9' {
-			return str, p.undo()
+			return sb.String(), p.undo()
 		}
-		str += string(r)
+		sb.WriteRune(r)
 	}
 }
 
@@ -91,7 +92,8 @@ func (p *parser) parseFraction() (string, error) {
 		return "", p.undo()
 	}
 
-	str := "."
+	var sb strings.Builder
+	sb.WriteRune('.')
 
 	for {
 		r, err := p.next()
@@ -104,9 +106,10 @@ func (p *parser) parseFraction() (string, error) {
 			}
 			break
 		}
-		str += string(r)
+		sb.WriteRune(r)
 	}
 
+	str := sb.String()
 	if str == "." {
 		return "", p.makeError("invalid number - missing digits after decimal point")
 	}
@@ -123,7 +126,8 @@ func (p *parser) parseExponent() (string, error) {
 		return "", p.undo()
 	}
 
-	str := string(r)
+	var sb strings.Builder
+	sb.WriteRune(r)
 
 	r, err = p.next()
 	if err != nil {
@@ -133,7 +137,8 @@ func (p *parser) parseExponent() (string, error) {
 	if r != '-' && r != '+' && !hasDigits {
 		return "", p.undo()
 	}
-	str += string(r)
+
+	sb.WriteRune(r)
 
 	for {
 		r, err := p.next()
@@ -147,12 +152,12 @@ func (p *parser) parseExponent() (string, error) {
 			break
 		}
 		hasDigits = true
-		str += string(r)
+		sb.WriteRune(r)
 	}
 
 	if !hasDigits {
 		return "", p.makeError("invalid number - no digits in exponent")
 	}
 
-	return str, nil
+	return sb.String(), nil
 }

--- a/pkg/scanners/azure/arm/parser/armjson/parse_string.go
+++ b/pkg/scanners/azure/arm/parser/armjson/parse_string.go
@@ -2,6 +2,7 @@ package armjson
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/aquasecurity/defsec/pkg/types"
 )
@@ -31,7 +32,7 @@ func (p *parser) parseString(parentMetadata *types.Metadata) (Node, error) {
 		return nil, p.makeError("expecting string delimiter")
 	}
 
-	var str string
+	var sb strings.Builder
 
 	var inEscape bool
 	var inHex bool
@@ -53,7 +54,7 @@ func (p *parser) parseString(parentMetadata *types.Metadata) (Node, error) {
 					if err != nil {
 						return nil, p.makeError("invalid unicode character '%s'", err)
 					}
-					str += char
+					sb.WriteString(char)
 					hex = nil
 				}
 			default:
@@ -69,20 +70,20 @@ func (p *parser) parseString(parentMetadata *types.Metadata) (Node, error) {
 			if !ok {
 				return nil, p.makeError("invalid escape sequence '\\%c'", c)
 			}
-			str += seq
+			sb.WriteString(seq)
 		} else {
 			switch c {
 			case '\\':
 				inEscape = true
 			case '"':
-				n.raw = str
+				n.raw = sb.String()
 				n.end = p.position
 				return n, nil
 			default:
 				if c < 0x20 || c > 0x10FFFF {
 					return nil, p.makeError("invalid unescaped character '0x%X'", c)
 				}
-				str += string(c)
+				sb.WriteRune(c)
 			}
 		}
 

--- a/pkg/scanners/azure/expressions/lex.go
+++ b/pkg/scanners/azure/expressions/lex.go
@@ -91,7 +91,7 @@ func (l *lexer) Lex() ([]Token, error) {
 }
 
 func (l *lexer) lexString(terminator rune) (Token, error) {
-	var raw string
+	var sb strings.Builder
 	for {
 		r, err := l.read()
 		if err != nil {
@@ -102,17 +102,17 @@ func (l *lexer) lexString(terminator rune) (Token, error) {
 			if err != nil {
 				return Token{}, fmt.Errorf("bad escape: %w", err)
 			}
-			raw += string(r)
+			sb.WriteRune(r)
 			continue
 		}
 		if r == terminator {
 			break
 		}
-		raw += string(r)
+		sb.WriteRune(r)
 	}
 	return Token{
 		Type: TokenLiteralString,
-		Data: raw,
+		Data: sb.String(),
 	}, nil
 }
 
@@ -137,7 +137,7 @@ func (l *lexer) readEscapedChar() (rune, error) {
 
 func (l *lexer) lexNumber() (Token, error) {
 
-	var raw string
+	var sb strings.Builder
 	var decimal bool
 
 LOOP:
@@ -149,15 +149,16 @@ LOOP:
 		switch r {
 		case '.':
 			decimal = true
-			raw += "."
+			sb.WriteRune('.')
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			raw += string(r)
+			sb.WriteRune(r)
 		default:
 			l.unread()
 			break LOOP
 		}
 	}
 
+	raw := sb.String()
 	if decimal {
 		fl, err := strconv.ParseFloat(raw, 64)
 		if err != nil {
@@ -180,7 +181,7 @@ LOOP:
 }
 
 func (l *lexer) lexKeyword() Token {
-	var raw string
+	var sb strings.Builder
 LOOP:
 	for {
 		r, err := l.read()
@@ -189,7 +190,7 @@ LOOP:
 		}
 		switch {
 		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
-			raw += string(r)
+			sb.WriteRune(r)
 		default:
 			l.unread()
 			break LOOP
@@ -197,6 +198,6 @@ LOOP:
 	}
 	return Token{
 		Type: TokenName,
-		Data: raw,
+		Data: sb.String(),
 	}
 }


### PR DESCRIPTION
Currently, in some places, when parsing ARM the resulting string is created by concatenation. Since string is a primitive type and a new string will be created each time, this is not effective. In go 1.10, was added [strings.Builder](https://pkg.go.dev/strings#Builder ), which effectively creates a string - O(n).

See https://github.com/aquasecurity/defsec/issues/1108

```shell
benchstat concat=old.txt strings.Builder=new.txt
goos: darwin
goarch: arm64
pkg: github.com/aquasecurity/defsec/pkg/scanners/azure/arm/parser/armjson
                        │    concat    │            strings.Builder            │
                        │    sec/op    │    sec/op     vs base                 │
Unmarshal_JFather-8       25.45µ ± ∞ ¹   17.54µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Unmarshal_Traditional-8   4.705µ ± ∞ ¹   4.934µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                   10.94µ         9.303µ        -14.99%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                        │    concat     │            strings.Builder             │
                        │     B/op      │     B/op       vs base                 │
Unmarshal_JFather-8       27.38Ki ± ∞ ¹   22.13Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
Unmarshal_Traditional-8   2.516Ki ± ∞ ¹   2.516Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                   8.300Ki         7.462Ki        -10.10%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal

                        │   concat    │           strings.Builder            │
                        │  allocs/op  │  allocs/op   vs base                 │
Unmarshal_JFather-8       724.0 ± ∞ ¹   251.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
Unmarshal_Traditional-8   57.00 ± ∞ ¹   57.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                   203.1         119.6        -41.12%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
```

Testing the `detection`. I added the `IsType_BigJson` test with the file from [this](https://github.com/aquasecurity/defsec/issues/1108#issuecomment-1471973890) comment.
```
benchstat concat=old.txt strings.Builder=new.txt
goos: darwin
goarch: arm64
pkg: github.com/aquasecurity/defsec/pkg/detection
                   │     concat      │            strings.Builder            │
                   │     sec/op      │    sec/op     vs base                 │
IsType_SmallFile-8      2.120µ ± ∞ ¹   1.710µ ± ∞ ¹        ~ (p=1.000 n=1) ²
IsType_BigFile-8        641.5n ± ∞ ¹   658.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
IsType_BigJson-8     464078.7µ ± ∞ ¹   793.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                 85.78µ         9.629µ        -88.77%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                   │      concat       │            strings.Builder             │
                   │       B/op        │     B/op       vs base                 │
IsType_SmallFile-8       5.760Ki ± ∞ ¹   5.595Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
IsType_BigFile-8         4.298Ki ± ∞ ¹   4.298Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
IsType_BigJson-8     6955356.7Ki ± ∞ ¹   508.5Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                  556.3Ki         23.04Ki        -95.86%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal

                   │     concat      │           strings.Builder            │
                   │    allocs/op    │  allocs/op   vs base                 │
IsType_SmallFile-8       57.00 ± ∞ ¹   26.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
IsType_BigFile-8         7.000 ± ∞ ¹   7.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
IsType_BigJson-8     232617.00 ± ∞ ¹   48.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                  452.8         20.60        -95.45%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
```