### PR TITLE
fix(windows): Use correct homedir on Windows

### DIFF
--- a/pkg/scanners/cloud/aws/scanner.go
+++ b/pkg/scanners/cloud/aws/scanner.go
@@ -220,7 +220,8 @@ func (s *Scanner) initRegoScanner() (*rego.Scanner, error) {
 	srcFS := s.policyFS
 	if srcFS == nil {
 		if runtime.GOOS == "windows" {
-			srcFS = os.DirFS("C:\\")
+			homeDir, _ := os.UserHomeDir()
+			srcFS = os.DirFS(homeDir)
 		} else {
 			srcFS = os.DirFS("/")
 		}


### PR DESCRIPTION
Currently we default to using `C:\` which is not correct at all times.