### PR TITLE
fix(terraform): allow nullable value for default values of vars

### DIFF
--- a/pkg/scanners/terraform/parser/evaluator.go
+++ b/pkg/scanners/terraform/parser/evaluator.go
@@ -347,7 +347,7 @@ func (e *evaluator) evaluateVariable(b *terraform.Block) (cty.Value, error) {
 		return cty.NilVal, fmt.Errorf("cannot resolve variable with no attributes")
 	}
 	if def, exists := attributes["default"]; exists {
-		return def.Value(), nil
+		return def.NullableValue(), nil
 	}
 	return cty.NilVal, fmt.Errorf("no value found")
 }

--- a/pkg/terraform/attribute.go
+++ b/pkg/terraform/attribute.go
@@ -253,6 +253,23 @@ func (a *Attribute) Value() (ctyVal cty.Value) {
 	return ctyVal
 }
 
+// Allows a null value for a variable https://developer.hashicorp.com/terraform/language/expressions/types#null
+func (a *Attribute) NullableValue() (ctyVal cty.Value) {
+	if a == nil {
+		return cty.NilVal
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			ctyVal = cty.NilVal
+		}
+	}()
+	ctyVal, _ = a.hclAttribute.Expr.Value(a.ctx.Inner())
+	if !ctyVal.IsKnown() {
+		return cty.NilVal
+	}
+	return ctyVal
+}
+
 func (a *Attribute) Name() string {
 	if a == nil {
 		return ""


### PR DESCRIPTION
Evaluating an expression like `attr = var.some_var != null ? var.some_var : "default"` fails: `The true and false result expression must have consistent types`.
Terraform [supports null](https://developer.hashicorp.com/terraform/language/expressions/types#null) values that have no type. But defsec converts null with type [DynamicPseudoTypes](https://github.com/zclconf/go-cty/blob/7dcbae46a6f247e983efb1fa774d2bb68781a333/cty/unknown.go#L59) to `city.NilVal`, which cannot be used in conditional expressions.

See https://github.com/aquasecurity/trivy/discussions/4736