### PR TITLE
feat(terraform): support for multiple instances of the same resource

### DIFF
--- a/pkg/scanners/terraform/parser/evaluator.go
+++ b/pkg/scanners/terraform/parser/evaluator.go
@@ -399,7 +399,7 @@ func (e *evaluator) getValuesByBlockType(blockType string) cty.Value {
 				continue
 			}
 
-			blockMap, ok := values[b.Label()]
+			blockMap, ok := values[b.Labels()[0]]
 			if !ok {
 				values[b.Labels()[0]] = cty.ObjectVal(make(map[string]cty.Value))
 				blockMap = values[b.Labels()[0]]


### PR DESCRIPTION
Now the resource instance overwrites the context variables of the previous instances, which makes it impossible to use multiple instances of the same resource.

See https://github.com/aquasecurity/trivy/issues/4627