### PR TITLE
fix(docker): check the `--no-install-recommends` flag after packages

### DIFF
--- a/rules/docker/policies/apt_get_missing_no_install_recommends.rego
+++ b/rules/docker/policies/apt_get_missing_no_install_recommends.rego
@@ -68,6 +68,10 @@ no_install_flag := `--no-install-recommends`
 
 optional_not_related_flags := `\s*(-(-)?[a-zA-Z]+\s*)*`
 
+# https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source
+# https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+pkgs := `([a-z\d][a-z\d+\-.]+(?:=[\w.+\-~:]+)?\s*)*`
+
 combined_flags := sprintf(`%s%s%s`, [optional_not_related_flags, no_install_flag, optional_not_related_flags])
 
 # flags before command
@@ -79,5 +83,11 @@ includes_no_install_recommends(command) {
 # flags behind command
 includes_no_install_recommends(command) {
 	install_regexp := sprintf(`apt-get%sinstall%s`, [optional_not_related_flags, combined_flags])
+	regex.match(install_regexp, command)
+}
+
+# flags after pkgs
+includes_no_install_recommends(command) {
+	install_regexp := sprintf(`apt-get%sinstall%s%s%s`, [optional_not_related_flags, optional_not_related_flags, pkgs, combined_flags])
 	regex.match(install_regexp, command)
 }

--- a/rules/docker/policies/apt_get_missing_no_install_recommends_test.rego
+++ b/rules/docker/policies/apt_get_missing_no_install_recommends_test.rego
@@ -103,3 +103,17 @@ test_chained_allowed {
 
 	count(r) == 0
 }
+
+test_flags_after_pkgs_allowed {
+	r := deny with input as {"Stages": [{"Name": "debian:11-slim", "Commands": [
+		{
+			"Cmd": "from",
+			"Value": ["debian:11-slim"],
+		},
+		{
+			"Cmd": "run",
+			"Value": ["apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata postgresql-10 --no-install-recommends && rm -rf /var/lib/apt/lists/*"],
+		},
+	]}]}
+	count(r) == 0
+}


### PR DESCRIPTION
We should also check the `--no-install-recommends` flag after packages

See https://github.com/aquasecurity/trivy/issues/4462

```Dockerfile
FROM debian:11-slim

RUN apt-get update && \
    DEBIAN_FRONTEND=noninteractive apt-get install -y \
    tzdata \
    postgresql-10 \
    --no-install-recommends && \ 
    rm -rf /var/lib/apt/lists/*
```

### Before
```shell
AVD-DS-0026 dockerfile-general-no-healthcheck Dockerfile
AVD-DS-0029 dockerfile-general-use-apt-no-install-recommends Dockerfile:3-8
AVD-DS-0002 dockerfile-general-least-privilege-user Dockerfile
```
### After
```
AVD-DS-0002 dockerfile-general-least-privilege-user Dockerfile
AVD-DS-0026 dockerfile-general-no-healthcheck Dockerfile
```
