### PR TITLE
fix(arm): use correct type casting for ints in azure scan

### DIFF
--- a/pkg/scanners/azure/value.go
+++ b/pkg/scanners/azure/value.go
@@ -225,7 +225,7 @@ func (v Value) AsInt() int {
 	if v.Kind != KindNumber {
 		return 0
 	}
-	return int(v.rLit.(float64))
+	return int(v.rLit.(int64))
 }
 
 func (v Value) AsFloat() float64 {

--- a/pkg/scanners/azure/value_test.go
+++ b/pkg/scanners/azure/value_test.go
@@ -1,0 +1,13 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValueAsInt(t *testing.T) {
+	val := NewValue(int64(10), types.NewTestMetadata())
+	assert.Equal(t, 10, val.AsInt())
+}


### PR DESCRIPTION
The wrong type was used when converting the value to `int`.

See https://github.com/aquasecurity/trivy/issues/4792

Example to reproduce the problem:
```json
{
    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
    "contentVersion": "2.0.0.0",
    "apiProfile": "2019-03-01-hybrid",
    "parameters": {},
    "variables": {},
    "functions": [],
    "resources": [
        {
            "name": "flowlogs/sample",
            "type": "Microsoft.Network/networkWatchers/flowLogs",
            "apiVersion": "2020-11-01",
            "location": "location",
            "tags": {},
            "properties": {
                "targetResourceId": "targetResourceId",
                "storageId": "storageId",
                "enabled": true,
                "retentionPolicy": {
                    "days": 2
                },
                "format": {
                    "type": "JSON"
                }
            }
        }
    ],
    "outputs": {}
}
```