### PR TITLE
fix(doc): update the links to authorized_ip_ranges

### DIFF
--- a/avd_docs/azure/container/AVD-AZU-0041/Terraform.md
+++ b/avd_docs/azure/container/AVD-AZU-0041/Terraform.md
@@ -15,5 +15,5 @@ Limit the access to the API server to a limited IP range
 ```
 
 #### Remediation Links
- - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#api_server_authorized_ip_ranges
+ - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#authorized_ip_ranges
 

--- a/rules/cloud/policies/azure/container/limit_authorized_ips.tf.go
+++ b/rules/cloud/policies/azure/container/limit_authorized_ips.tf.go
@@ -23,7 +23,7 @@ var terraformLimitAuthorizedIpsBadExamples = []string{
 }
 
 var terraformLimitAuthorizedIpsLinks = []string{
-	`https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#api_server_authorized_ip_ranges`,
+	`https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#authorized_ip_ranges`,
 }
 
 var terraformLimitAuthorizedIpsRemediationMarkdown = ``


### PR DESCRIPTION
The `api_server_authorized_ip_ranges` field is deprecated, replaced the links with `authorized_ip_range`.

See https://github.com/aquasecurity/trivy/issues/4624

Related PR:
- https://github.com/aquasecurity/defsec/pull/1254