### PR TITLE
feat: add the occurrences field

### DIFF
--- a/pkg/scan/flat.go
+++ b/pkg/scan/flat.go
@@ -20,6 +20,7 @@ type FlatResult struct {
 	Warning         bool               `json:"warning"`
 	Status          Status             `json:"status"`
 	Resource        string             `json:"resource"`
+	Occurrences     []Occurrence       `json:"occurrences,omitempty"`
 	Location        FlatRange          `json:"location"`
 }
 
@@ -60,6 +61,7 @@ func (r *Result) Flatten() FlatResult {
 		Severity:        r.rule.Severity,
 		Status:          r.status,
 		Resource:        resMetadata.Reference(),
+		Occurrences:     r.Occurrences(),
 		Warning:         r.IsWarning(),
 		Location: FlatRange{
 			Filename:  rng.GetFilename(),

--- a/pkg/scan/result.go
+++ b/pkg/scan/result.go
@@ -336,3 +336,37 @@ func rawToString(raw interface{}) string {
 		return "?"
 	}
 }
+
+type Occurrence struct {
+	Resource  string `json:"resource"`
+	Filename  string `json:"filename"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+}
+
+func (r *Result) Occurrences() []Occurrence {
+	var occurrences []Occurrence
+
+	mod := &r.metadata
+	prevFileName := mod.Range().GetFilename()
+
+	for {
+		mod = mod.Parent()
+		if mod == nil {
+			break
+		}
+		parentRange := mod.Range()
+		fileName := parentRange.GetFilename()
+		if fileName == prevFileName {
+			continue
+		}
+		prevFileName = fileName
+		occurrences = append(occurrences, Occurrence{
+			Resource:  mod.Reference(),
+			Filename:  parentRange.GetFilename(),
+			StartLine: parentRange.GetStartLine(),
+			EndLine:   parentRange.GetEndLine(),
+		})
+	}
+	return occurrences
+}

--- a/pkg/scan/result.go
+++ b/pkg/scan/result.go
@@ -348,7 +348,6 @@ func (r *Result) Occurrences() []Occurrence {
 	var occurrences []Occurrence
 
 	mod := &r.metadata
-	prevFileName := mod.Range().GetFilename()
 
 	for {
 		mod = mod.Parent()
@@ -356,11 +355,6 @@ func (r *Result) Occurrences() []Occurrence {
 			break
 		}
 		parentRange := mod.Range()
-		fileName := parentRange.GetFilename()
-		if fileName == prevFileName {
-			continue
-		}
-		prevFileName = fileName
 		occurrences = append(occurrences, Occurrence{
 			Resource:  mod.Reference(),
 			Filename:  parentRange.GetFilename(),

--- a/pkg/scan/result_test.go
+++ b/pkg/scan/result_test.go
@@ -1,0 +1,56 @@
+package scan_test
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/scan"
+	"github.com/aquasecurity/defsec/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Occurrences(t *testing.T) {
+	tests := []struct {
+		name     string
+		factory  func() *scan.Result
+		expected []scan.Occurrence
+	}{
+		{
+			name: "happy",
+			factory: func() *scan.Result {
+				r := scan.Result{}
+				causeResourceMeta := types.NewMetadata(types.NewRange(
+					"main.tf", 1, 13, "", nil,
+				), "module.aws-security-groups[\"db1\"]")
+
+				parentMeta := types.NewMetadata(types.NewRange(
+					"terraform-aws-modules/security-group/aws/main.tf", 191, 227, "", nil,
+				), "aws_security_group_rule.ingress_with_cidr_blocks[0]").WithParent(causeResourceMeta)
+
+				r.OverrideMetadata(types.NewMetadata(types.NewRange(
+					"terraform-aws-modules/security-group/aws/main.tf", 197, 204, "", nil,
+				), "aws_security_group_rule.ingress_with_cidr_blocks").WithParent(parentMeta))
+				return &r
+			},
+			expected: []scan.Occurrence{
+				{
+					Resource:  "aws_security_group_rule.ingress_with_cidr_blocks[0]",
+					Filename:  "terraform-aws-modules/security-group/aws/main.tf",
+					StartLine: 191,
+					EndLine:   227,
+				},
+				{
+					Resource:  "module.aws-security-groups[\"db1\"]",
+					Filename:  "main.tf",
+					StartLine: 1,
+					EndLine:   13,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.factory().Occurrences())
+		})
+	}
+}


### PR DESCRIPTION
Added the `occurrences` field. Based on this field, we can display a list of occurrences in reports.
See https://github.com/aquasecurity/trivy/issues/4581

Example of json output:
```json
{
  "results": [
    {
      "rule_id": "AVD-AWS-0107",
      "long_id": "aws-ec2-no-public-ingress-sgr",
      "rule_description": "An ingress security group rule allows traffic from /0.",
      "rule_provider": "aws",
      "rule_service": "ec2",
      "impact": "Your port exposed to the internet",
      "resolution": "Set a more restrictive cidr range",
      "links": [
        "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html"
      ],
      "description": "Security group rule allows ingress from public internet.",
      "severity": "CRITICAL",
      "warning": false,
      "status": 0,
      "resource": "module.aws-security-groups[\"db1\"]",
      "occurrences": [
        {
          "resource": "aws_security_group_rule.ingress_with_cidr_blocks[0]",
          "filename": "terraform-aws-modules/security-group/aws/main.tf",
          "start_line": 191,
          "end_line": 227
        },
        {
          "resource": "module.aws-security-groups[\"db1\"]",
          "filename": "sg.tf",
          "start_line": 1,
          "end_line": 13
        }
      ],
      "location": {
        "filename": "terraform-aws-modules/security-group/aws/main.tf",
        "start_line": 197,
        "end_line": 204
      }
    }
  ]
}
```