### PR TITLE
fix(docker): check the `-y` flag after packages

### DIFF
--- a/rules/docker/policies/apt_get_missing_yes_flag_to_avoid_manual_input.rego
+++ b/rules/docker/policies/apt_get_missing_yes_flag_to_avoid_manual_input.rego
@@ -68,6 +68,10 @@ short_flags := `(-([a-xzA-XZ])*y([a-xzA-XZ])*)`
 
 long_flags := `(--yes)|(--assume-yes)`
 
+# https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source
+# https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+pkgs := `([a-z\d][a-z\d+\-.]+(?:=[\w.+\-~:]+)?\s*)*`
+
 optional_not_related_flags := `\s*(-(-)?[a-zA-Z]+\s*)*`
 
 combined_flags := sprintf(`%s(%s|%s)%s`, [optional_not_related_flags, short_flags, long_flags, optional_not_related_flags])
@@ -81,5 +85,11 @@ includes_assume_yes(command) {
 # flags behind command
 includes_assume_yes(command) {
 	install_regexp := sprintf(`apt-get%sinstall%s`, [optional_not_related_flags, combined_flags])
+	regex.match(install_regexp, command)
+}
+
+# flags after pkgs
+includes_assume_yes(command) {
+	install_regexp := sprintf(`apt-get%sinstall%s%s%s`, [optional_not_related_flags, optional_not_related_flags, pkgs, combined_flags])
 	regex.match(install_regexp, command)
 }

--- a/rules/docker/policies/apt_get_missing_yes_flag_to_avoid_manual_input_test.rego
+++ b/rules/docker/policies/apt_get_missing_yes_flag_to_avoid_manual_input_test.rego
@@ -136,3 +136,17 @@ test_chained_allowed {
 
 	count(r) == 0
 }
+
+test_flags_after_pkgs_allowed {
+	r := deny with input as {"Stages": [{"Name": "debian:11-slim", "Commands": [
+		{
+			"Cmd": "from",
+			"Value": ["debian:11-slim"],
+		},
+		{
+			"Cmd": "run",
+			"Value": ["apt-get update && apt-get install tzdata postgresql-10 -y && rm -rf /var/lib/apt/lists/*"],
+		},
+	]}]}
+	count(r) == 0
+}


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/defsec/issues/1173

Dockerfile:
```Dockerfile
FROM debian:11-slim
RUN apt-get install apt-utils -y
```

### Before
```shell
AVD-DS-0029 dockerfile-general-use-apt-no-install-recommends Dockerfile:2
AVD-DS-0002 dockerfile-general-least-privilege-user Dockerfile
AVD-DS-0026 dockerfile-general-no-healthcheck Dockerfile
AVD-DS-0021 dockerfile-general-use-apt-auto-confirm Dockerfile:2
```

### After
```shell
AVD-DS-0002 dockerfile-general-least-privilege-user Dockerfile
AVD-DS-0029 dockerfile-general-use-apt-no-install-recommends Dockerfile:2
AVD-DS-0026 dockerfile-general-no-healthcheck Dockerfile
```
