### PR TITLE
fix(cloudformation): set context for conditions

### DIFF
--- a/pkg/scanners/cloudformation/parser/fn_ref.go
+++ b/pkg/scanners/cloudformation/parser/fn_ref.go
@@ -19,6 +19,10 @@ func ResolveReference(property *Property) (resolved *Property, success bool) {
 		return property.deriveResolved(cftypes.String, pseudo.(string)), true
 	}
 
+	if property.ctx == nil {
+		return property, false
+	}
+
 	var param *Parameter
 	for k := range property.ctx.Parameters {
 		if k == refValue {

--- a/pkg/scanners/cloudformation/parser/parser.go
+++ b/pkg/scanners/cloudformation/parser/parser.go
@@ -145,6 +145,11 @@ func (p *Parser) ParseFile(ctx context.Context, fs fs.FS, path string) (context 
 
 	p.debug.Log("Context loaded from source %s", path)
 
+	// the context must be set to conditions before resources
+	for _, c := range context.Conditions {
+		c.setContext(context)
+	}
+
 	for name, r := range context.Resources {
 		r.ConfigureResource(name, fs, path, context)
 	}


### PR DESCRIPTION
The context of the file was not set for the conditions, so they could not refer to the parameters.

See: https://github.com/aquasecurity/trivy/issues/3418