### PR TITLE
fix(cloudformation): resolve property depending on conditions

### DIFF
--- a/pkg/scanners/cloudformation/parser/property.go
+++ b/pkg/scanners/cloudformation/parser/property.go
@@ -241,13 +241,17 @@ func (p *Property) GetProperty(path string) *Property {
 	pathParts := strings.Split(path, ".")
 
 	first := pathParts[0]
-	var property *Property
+	property := p
 
-	if p.IsNotMap() {
+	if p.isFunction() {
+		property, _ = p.resolveValue()
+	}
+
+	if property.IsNotMap() {
 		return nil
 	}
 
-	for n, p := range p.AsMap() {
+	for n, p := range property.AsMap() {
 		if n == first {
 			property = p
 			break

--- a/pkg/scanners/cloudformation/parser/resource_test.go
+++ b/pkg/scanners/cloudformation/parser/resource_test.go
@@ -1,0 +1,75 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/scanners/cloudformation/cftypes"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetProperty_PropIsFunction(t *testing.T) {
+	resource := Resource{
+		Inner: ResourceInner{
+			Type: "AWS::S3::Bucket",
+			Properties: map[string]*Property{
+				"BucketName": {
+					Inner: PropertyInner{
+						Type:  cftypes.String,
+						Value: "mybucket",
+					},
+				},
+				"VersioningConfiguration": {
+					Inner: PropertyInner{
+						Type: cftypes.Map,
+						Value: map[string]*Property{
+							"Fn::If": {
+								Inner: PropertyInner{
+									Type: cftypes.List,
+									Value: []*Property{
+										{
+											Inner: PropertyInner{
+												Type:  cftypes.Bool,
+												Value: false,
+											},
+										},
+										{
+											Inner: PropertyInner{
+												Type: cftypes.Map,
+												Value: map[string]*Property{
+													"Status": {
+														Inner: PropertyInner{
+															Type:  cftypes.String,
+															Value: "Enabled",
+														},
+													},
+												},
+											},
+										},
+										{
+											Inner: PropertyInner{
+												Type: cftypes.Map,
+												Value: map[string]*Property{
+													"Status": {
+														Inner: PropertyInner{
+															Type:  cftypes.String,
+															Value: "Suspended",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prop := resource.GetProperty("VersioningConfiguration.Status")
+	require.NotNil(t, prop)
+	require.True(t, prop.IsString())
+	require.Equal(t, "Suspended", prop.AsString())
+}


### PR DESCRIPTION
When a property is a value returned by a condition, then defsec does not evaluate it

Example:
```yaml
Resources:
  Bucket:
    Type: "AWS::S3::Bucket"
    Properties:
      VersioningConfiguration:
        !If [true, { Status: Enabled }, { Status: Suspended }]
```

Output:
```bash
....
AVD-AWS-0090 aws-s3-enable-versioning test.yaml:2-6
....
```

See https://github.com/aquasecurity/trivy/issues/4844