### PR TITLE
fix(azure): `SecurityAlertPolicies`: don't warn if policy is disabled

### DIFF
--- a/internal/adapters/arm/database/mssql.go
+++ b/internal/adapters/arm/database/mssql.go
@@ -44,6 +44,7 @@ func adaptSecurityAlertPolicies(resource azure.Resource, deployment azure.Deploy
 	for _, policy := range deployment.GetResourcesByType("Microsoft.Sql/servers/securityAlertPolicies") {
 		policies = append(policies, database.SecurityAlertPolicy{
 			Metadata:           policy.Metadata,
+			State:              resource.Properties.GetMapValue("state").AsStringValue("", resource.Metadata),
 			EmailAddresses:     adaptStringList(policy.Properties.GetMapValue("emailAddresses")),
 			DisabledAlerts:     adaptStringList(policy.Properties.GetMapValue("disabledAlerts")),
 			EmailAccountAdmins: policy.Properties.GetMapValue("emailAccountAdmins").AsBoolValue(false, policy.Metadata),

--- a/internal/adapters/terraform/azure/database/adapt.go
+++ b/internal/adapters/terraform/azure/database/adapt.go
@@ -400,6 +400,9 @@ func adaptPostgreSQLConfig(resource *terraform.Block, configBlocks []*terraform.
 
 func adaptMSSQLSecurityAlertPolicy(resource *terraform.Block) database.SecurityAlertPolicy {
 
+	stateAttr := resource.GetAttribute("state")
+	stateVal := stateAttr.AsStringValueOrDefault("", resource)
+
 	emailAddressesAttr := resource.GetAttribute("email_addresses")
 	disabledAlertsAttr := resource.GetAttribute("disabled_alerts")
 
@@ -408,6 +411,7 @@ func adaptMSSQLSecurityAlertPolicy(resource *terraform.Block) database.SecurityA
 
 	return database.SecurityAlertPolicy{
 		Metadata:           resource.GetMetadata(),
+		State:              stateVal,
 		EmailAddresses:     emailAddressesAttr.AsStringValues(),
 		DisabledAlerts:     disabledAlertsAttr.AsStringValues(),
 		EmailAccountAdmins: emailAccountAdminsVal,

--- a/pkg/providers/azure/database/database.go
+++ b/pkg/providers/azure/database/database.go
@@ -45,12 +45,14 @@ type Server struct {
 type MSSQLServer struct {
 	Metadata defsecTypes.Metadata
 	Server
+	State                    defsecTypes.StringValue
 	ExtendedAuditingPolicies []ExtendedAuditingPolicy
 	SecurityAlertPolicies    []SecurityAlertPolicy
 }
 
 type SecurityAlertPolicy struct {
 	Metadata           defsecTypes.Metadata
+	State              defsecTypes.StringValue
 	EmailAddresses     []defsecTypes.StringValue
 	DisabledAlerts     []defsecTypes.StringValue
 	EmailAccountAdmins defsecTypes.BoolValue

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -3812,6 +3812,10 @@
         "server": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.azure.database.Server"
+        },
+        "state": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
         }
       }
     },
@@ -3883,6 +3887,10 @@
             "type": "object",
             "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
           }
+        },
+        "state": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
         }
       }
     },

--- a/rules/cloud/policies/azure/database/threat_alert_email_set.go
+++ b/rules/cloud/policies/azure/database/threat_alert_email_set.go
@@ -30,7 +30,7 @@ var CheckThreatAlertEmailSet = rules.Register(
 	func(s *state.State) (results scan.Results) {
 		for _, server := range s.Azure.Database.MSSQLServers {
 			for _, policy := range server.SecurityAlertPolicies {
-				if len(policy.EmailAddresses) == 0 {
+				if len(policy.EmailAddresses) == 0 && policy.State.NotEqualTo("Disabled") {
 					results.Add(
 						"Security alert policy does not include any email addresses for notification.",
 						&policy,

--- a/rules/cloud/policies/azure/database/threat_alert_email_set_test.go
+++ b/rules/cloud/policies/azure/database/threat_alert_email_set_test.go
@@ -37,6 +37,24 @@ func TestCheckThreatAlertEmailSet(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "No email address provided for threat alerts, but alert is disabled",
+			input: database.Database{
+				MSSQLServers: []database.MSSQLServer{
+					{
+						Metadata: defsecTypes.NewTestMetadata(),
+						SecurityAlertPolicies: []database.SecurityAlertPolicy{
+							{
+								Metadata:       defsecTypes.NewTestMetadata(),
+								State:          defsecTypes.String("Disabled", defsecTypes.NewTestMetadata()),
+								EmailAddresses: []defsecTypes.StringValue{},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
 			name: "Email address provided for threat alerts",
 			input: database.Database{
 				MSSQLServers: []database.MSSQLServer{

--- a/rules/cloud/policies/azure/database/threat_alert_email_to_owner.go
+++ b/rules/cloud/policies/azure/database/threat_alert_email_to_owner.go
@@ -30,7 +30,7 @@ var CheckThreatAlertEmailToOwner = rules.Register(
 	func(s *state.State) (results scan.Results) {
 		for _, server := range s.Azure.Database.MSSQLServers {
 			for _, policy := range server.SecurityAlertPolicies {
-				if policy.EmailAccountAdmins.IsFalse() {
+				if policy.EmailAccountAdmins.IsFalse() && policy.State.NotEqualTo("Disabled") {
 					results.Add(
 						"Security alert policy does not alert account admins.",
 						policy.EmailAccountAdmins,


### PR DESCRIPTION
Hi,

Azure's MSSql SecurityAlertPolicies can be disabled. In this case, it's okay to not have email addresses.

Cheers