### PR TITLE
fix: set HostnameImmutable if a custom endpoint is used

### DIFF
--- a/internal/adapters/cloud/aws/adapt.go
+++ b/internal/adapters/cloud/aws/adapt.go
@@ -112,9 +112,10 @@ type resolver struct {
 
 func (r *resolver) ResolveEndpoint(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
 	return aws.Endpoint{
-		URL:           r.endpoint,
-		SigningRegion: "custom-signing-region",
-		Source:        aws.EndpointSourceCustom,
+		URL:               r.endpoint,
+		SigningRegion:     "custom-signing-region",
+		Source:            aws.EndpointSourceCustom,
+		HostnameImmutable: true,
 	}, nil
 }
 


### PR DESCRIPTION
Amazon S3 supports both virtual-hosted–style and path-style URL acces, but the `GetBucketLocation` method uses virtual-hosted–style, which does not support localstack. `HostnameImmutable` flag [does not allow](https://github.com/aws/aws-sdk-go-v2/blob/main/aws/endpoints.go#L102) the sdk to change the endpoint. This will allow us to use localstack for local testing.

See https://github.com/aquasecurity/trivy/issues/4876