### PR TITLE
feat(cloud): add availability zone filed for rds cluster

### DIFF
--- a/internal/adapters/cloud/aws/rds/rds.go
+++ b/internal/adapters/cloud/aws/rds/rds.go
@@ -248,6 +248,11 @@ func (a *adapter) adaptCluster(dbCluster types.DBCluster) (*rds.Cluster, error) 
 		engine = *dbCluster.Engine
 	}
 
+	var availabilityZones []defsecTypes.StringValue
+	for _, az := range dbCluster.AvailabilityZones {
+		availabilityZones = append(availabilityZones, defsecTypes.String(az, dbClusterMetadata))
+	}
+
 	cluster := &rds.Cluster{
 		Metadata:                  dbClusterMetadata,
 		BackupRetentionPeriodDays: defsecTypes.IntFromInt32(aws.ToInt32(dbCluster.BackupRetentionPeriod), dbClusterMetadata),
@@ -261,6 +266,7 @@ func (a *adapter) adaptCluster(dbCluster types.DBCluster) (*rds.Cluster, error) 
 		PublicAccess:         defsecTypes.Bool(aws.ToBool(dbCluster.PubliclyAccessible), dbClusterMetadata),
 		Engine:               defsecTypes.String(engine, dbClusterMetadata),
 		LatestRestorableTime: defsecTypes.TimeUnresolvable(dbClusterMetadata),
+		AvailabilityZones:    availabilityZones,
 	}
 
 	return cluster, nil

--- a/internal/adapters/cloudformation/aws/rds/cluster.go
+++ b/internal/adapters/cloudformation/aws/rds/cluster.go
@@ -27,6 +27,7 @@ func getClusters(ctx parser.FileContext) (clusters map[string]rds.Cluster) {
 			PublicAccess:         defsecTypes.BoolDefault(false, clusterResource.Metadata()),
 			Engine:               defsecTypes.StringDefault(rds.EngineAurora, clusterResource.Metadata()),
 			LatestRestorableTime: defsecTypes.TimeUnresolvable(clusterResource.Metadata()),
+			AvailabilityZones:    nil,
 		}
 
 		if engineProp := clusterResource.GetProperty("Engine"); engineProp.IsString() {

--- a/internal/adapters/cloudformation/aws/rds/cluster.go
+++ b/internal/adapters/cloudformation/aws/rds/cluster.go
@@ -27,7 +27,6 @@ func getClusters(ctx parser.FileContext) (clusters map[string]rds.Cluster) {
 			PublicAccess:         defsecTypes.BoolDefault(false, clusterResource.Metadata()),
 			Engine:               defsecTypes.StringDefault(rds.EngineAurora, clusterResource.Metadata()),
 			LatestRestorableTime: defsecTypes.TimeUnresolvable(clusterResource.Metadata()),
-			AvailabilityZones:    nil,
 		}
 
 		if engineProp := clusterResource.GetProperty("Engine"); engineProp.IsString() {

--- a/internal/adapters/terraform/aws/rds/adapt.go
+++ b/internal/adapters/terraform/aws/rds/adapt.go
@@ -72,7 +72,6 @@ func getClusters(modules terraform.Modules) (clusters []rds.Cluster) {
 			PublicAccess:         defsecTypes.BoolDefault(false, defsecTypes.NewUnmanagedMetadata()),
 			Engine:               defsecTypes.StringUnresolvable(defsecTypes.NewUnmanagedMetadata()),
 			LatestRestorableTime: defsecTypes.TimeUnresolvable(defsecTypes.NewUnmanagedMetadata()),
-			AvailabilityZones:    nil,
 		}
 		for _, orphan := range orphanResources {
 			orphanage.Instances = append(orphanage.Instances, adaptClusterInstance(orphan, modules))

--- a/internal/adapters/terraform/aws/rds/adapt.go
+++ b/internal/adapters/terraform/aws/rds/adapt.go
@@ -72,6 +72,7 @@ func getClusters(modules terraform.Modules) (clusters []rds.Cluster) {
 			PublicAccess:         defsecTypes.BoolDefault(false, defsecTypes.NewUnmanagedMetadata()),
 			Engine:               defsecTypes.StringUnresolvable(defsecTypes.NewUnmanagedMetadata()),
 			LatestRestorableTime: defsecTypes.TimeUnresolvable(defsecTypes.NewUnmanagedMetadata()),
+			AvailabilityZones:    nil,
 		}
 		for _, orphan := range orphanResources {
 			orphanage.Instances = append(orphanage.Instances, adaptClusterInstance(orphan, modules))
@@ -223,6 +224,7 @@ func adaptCluster(resource *terraform.Block, modules terraform.Modules) (rds.Clu
 		PublicAccess:              defsecTypes.Bool(public, resource.GetMetadata()),
 		Engine:                    resource.GetAttribute("engine").AsStringValueOrDefault(rds.EngineAurora, resource),
 		LatestRestorableTime:      defsecTypes.TimeUnresolvable(resource.GetMetadata()),
+		AvailabilityZones:         resource.GetAttribute("availability_zones").AsStringValueSliceOrEmpty(resource),
 	}, ids
 }
 

--- a/internal/adapters/terraform/aws/rds/adapt_test.go
+++ b/internal/adapters/terraform/aws/rds/adapt_test.go
@@ -25,6 +25,7 @@ func Test_Adapt(t *testing.T) {
 
 			resource "aws_rds_cluster" "example" {
 				engine                  = "aurora-mysql"
+				availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
 				backup_retention_period = 7
 				kms_key_id  = "kms_key_1"
 				storage_encrypted = true
@@ -115,6 +116,11 @@ func Test_Adapt(t *testing.T) {
 						},
 						PublicAccess: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
 						Engine:       defsecTypes.String(rds.EngineAuroraMysql, defsecTypes.NewTestMetadata()),
+						AvailabilityZones: defsecTypes.StringValueList{
+							defsecTypes.String("us-west-2a", defsecTypes.NewTestMetadata()),
+							defsecTypes.String("us-west-2b", defsecTypes.NewTestMetadata()),
+							defsecTypes.String("us-west-2c", defsecTypes.NewTestMetadata()),
+						},
 					},
 				},
 				Classic: rds.Classic{

--- a/pkg/providers/aws/rds/rds.go
+++ b/pkg/providers/aws/rds/rds.go
@@ -46,6 +46,7 @@ type Cluster struct {
 	PublicAccess              defsecTypes.BoolValue
 	Engine                    defsecTypes.StringValue
 	LatestRestorableTime      defsecTypes.TimeValue
+	AvailabilityZones         []defsecTypes.StringValue
 }
 
 type Snapshots struct {

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -2379,6 +2379,13 @@
     "github.com.aquasecurity.defsec.pkg.providers.aws.rds.Cluster": {
       "type": "object",
       "properties": {
+        "availabilityzones": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
+          }
+        },
         "backupretentionperioddays": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.IntValue"


### PR DESCRIPTION
There is a behavior in `availability_zones` in `aws_rds_cluster` that may cause resource re-creation to be performed. An additional parameter has been added to allow inspection of this issue.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#availability_zones