### PR TITLE
Anonymous user access binding to RoleBinding and ClusterRoleBinding

### DIFF
--- a/avd_docs/kubernetes/general/AVD-KSV-0122/docs.md
+++ b/avd_docs/kubernetes/general/AVD-KSV-0122/docs.md
@@ -1,0 +1,13 @@
+
+Binding to anonymous user to any clusterrole or role is a security risk.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://kubernetes.io/docs/concepts/security/rbac-good-practices/
+
+

--- a/rules/kubernetes/policies/general/anonymous_user_bind.rego
+++ b/rules/kubernetes/policies/general/anonymous_user_bind.rego
@@ -1,0 +1,39 @@
+# METADATA
+# title: "Anonymous user access binding"
+# description: "Binding to anonymous user to any clusterrole or role is a security risk."
+# scope: package
+# schemas:
+# - input: schema["kubernetes"]
+# related_resources:
+# - https://blog.aquasec.com/kubernetes-exposed-one-yaml-away-from-disaster
+# custom:
+#   id: KSV122
+#   avd_id: AVD-KSV-0122
+#   severity: CRITICAL
+#   short_code: no-anonymous-user-bind
+#   recommended_action: "Remove anonymous user binding from clusterrolebinding or rolebinding."
+#   input:
+#     selector:
+#     - type: kubernetes
+#       subtypes:
+#         - kind: rolebinding
+#         - kind: clusterrolebinding
+
+package appshield.kubernetes.KSV122
+
+import data.lib.kubernetes
+
+readRoleRefs := ["system:unauthenticated", "system:anonymous"]
+
+readKinds := ["RoleBinding", "ClusterRolebinding"]
+
+anonymousUserBind(roleBinding) {
+	kubernetes.kind == readKinds[_]
+	kubernetes.object.subjects[_].name == readRoleRefs[_]
+}
+
+deny[res] {
+	anonymousUserBind(input)
+	msg := kubernetes.format(sprintf("%s '%s' should not bind to roles %s", [kubernetes.kind, kubernetes.name, readRoleRefs]))
+	res := result.new(msg, input.metadata)
+}

--- a/rules/kubernetes/policies/general/anonymous_user_bind_test.rego
+++ b/rules/kubernetes/policies/general/anonymous_user_bind_test.rego
@@ -1,0 +1,107 @@
+package appshield.kubernetes.KSV122
+
+# Test case for a RoleBinding with anonymous/unauthenticated user binding
+test_role_binding_with_anonymous_user_binding {
+    r := deny with input as {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {
+            "name": "anonymous_user",
+            "namespace": "default",
+        },
+        "subjects": [{
+            "kind": "User",
+            "name": "system:unauthenticated",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+        {
+            "kind": "User",
+            "name": "system:anonymous",
+            "apiGroup": "rbac.authorization.k8s.io",
+        }],
+        "roleRef": {
+            "kind": "Role",
+            "name": "role",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+    }
+
+	count(r) == 1
+}
+
+#Test case for a ClusterRoleBinding with anonymous/unauthenticated user binding
+test_cluster_role_binding_with_anonymous_user_binding {
+    r := deny with input as {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRolebinding",
+        "metadata": {
+            "name": "anonymous_user",
+            "namespace": "default",
+        },
+        "subjects": [{
+            "kind": "User",
+            "name": "system:unauthenticated",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+        {
+            "kind": "User",
+            "name": "system:anonymous",
+            "apiGroup": "rbac.authorization.k8s.io",
+        }],
+        "roleRef": {
+            "kind": "ClusterRole",
+            "name": "clusterrole",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+    }
+
+	count(r) == 1
+}
+
+# Test case for a RoleBinding with non-anonymous user binding
+test_role_binding_with_non_anonymous_user_binding {
+    r := deny with input as {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {
+            "name": "non_anonymous_user",
+            "namespace": "default",
+        },
+        "subjects": {
+            "kind": "User",
+            "name": "system:authenticated",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+        "roleRef": {
+            "kind": "Role",
+            "name": "role",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+    }
+
+	count(r) == 0
+}
+
+# Test case for a ClusterRoleBinding with non-anonymous user binding
+test_cluster_role_binding_with_non_anonymous_user_binding {
+    r := deny with input as {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRoleBinding",
+        "metadata": {
+            "name": "non_anonymous_user",
+            "namespace": "default",
+        },
+        "subjects": {
+            "kind": "User",
+            "name": "system:authenticated",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+        "roleRef": {
+            "kind": "ClusterRole",
+            "name": "clusterrole",
+            "apiGroup": "rbac.authorization.k8s.io",
+        },
+    }
+
+	count(r) == 0
+}


### PR DESCRIPTION
Added new rego check which checks Anonymous user access binding to rolebinding or clusterrolebinding.
The same is referred here https://blog.aquasec.com/kubernetes-exposed-one-yaml-away-from-disaster