### PR TITLE
Modified the Rego policies within Defsec to incorporate subtype selectors.

### DIFF
--- a/rules/kubernetes/policies/advanced/default_namespace_should_not_be_used.rego
+++ b/rules/kubernetes/policies/advanced/default_namespace_should_not_be_used.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV110
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/advanced/optional/capabilities_no_drop_at_least_one.rego
+++ b/rules/kubernetes/policies/advanced/optional/capabilities_no_drop_at_least_one.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV004
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/advanced/optional/manages_etc_hosts.rego
+++ b/rules/kubernetes/policies/advanced/optional/manages_etc_hosts.rego
@@ -13,6 +13,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV007
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/advanced/optional/uses_untrusted_azure_registry.rego
+++ b/rules/kubernetes/policies/advanced/optional/uses_untrusted_azure_registry.rego
@@ -13,6 +13,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV032
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/advanced/optional/uses_untrusted_ecr_registry.rego
+++ b/rules/kubernetes/policies/advanced/optional/uses_untrusted_ecr_registry.rego
@@ -13,6 +13,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV035
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/advanced/optional/uses_untrusted_gcr_registry.rego
+++ b/rules/kubernetes/policies/advanced/optional/uses_untrusted_gcr_registry.rego
@@ -13,6 +13,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV033
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/advanced/optional/uses_untrusted_public_registries.rego
+++ b/rules/kubernetes/policies/advanced/optional/uses_untrusted_public_registries.rego
@@ -13,6 +13,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV034
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/aquacommercial/configMap_with_secrets.rego
+++ b/rules/kubernetes/policies/aquacommercial/configMap_with_secrets.rego
@@ -13,7 +13,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
-
+#       subtypes:
+#         - kind: configmap
 package builtin.kubernetes.KSV0109
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego
+++ b/rules/kubernetes/policies/aquacommercial/configmap_with_sensitive.rego
@@ -13,7 +13,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
-
+#       subtypes:
+#         - kind: configmap
 package builtin.kubernetes.KSV01010
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/aquacommercial/service_with_externalip.rego
+++ b/rules/kubernetes/policies/aquacommercial/service_with_externalip.rego
@@ -13,6 +13,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: service
 package builtin.kubernetes.KSV0108
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/CPU_not_limited.rego
+++ b/rules/kubernetes/policies/general/CPU_not_limited.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV011
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/CPU_requests_not_specified.rego
+++ b/rules/kubernetes/policies/general/CPU_requests_not_specified.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV015
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/SYS_ADMIN_capability.rego
+++ b/rules/kubernetes/policies/general/SYS_ADMIN_capability.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV005
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/SYS_MODULE_capability.rego
+++ b/rules/kubernetes/policies/general/SYS_MODULE_capability.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV120
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/allowing_to_update_a_malicious_pod.rego
+++ b/rules/kubernetes/policies/general/allowing_to_update_a_malicious_pod.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV048
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/capabilities_no_drop_all.rego
+++ b/rules/kubernetes/policies/general/capabilities_no_drop_all.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV003
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/default_security_context.rego
+++ b/rules/kubernetes/policies/general/default_security_context.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV118
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/delete_pod_logs.rego
+++ b/rules/kubernetes/policies/general/delete_pod_logs.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV042
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/file_system_not_read_only.rego
+++ b/rules/kubernetes/policies/general/file_system_not_read_only.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV014
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/get_shell_on_pod.rego
+++ b/rules/kubernetes/policies/general/get_shell_on_pod.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV053
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_all_resources.rego
+++ b/rules/kubernetes/policies/general/manage_all_resources.rego
@@ -15,6 +15,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
 package builtin.kubernetes.KSV046
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_all_resources_at_namespace.rego
+++ b/rules/kubernetes/policies/general/manage_all_resources_at_namespace.rego
@@ -15,6 +15,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: role
 package builtin.kubernetes.KSV112
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_configmaps.rego
+++ b/rules/kubernetes/policies/general/manage_configmaps.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV049
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_eks_iam_auth_configmap.rego
+++ b/rules/kubernetes/policies/general/manage_eks_iam_auth_configmap.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV115
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_kubernetes_networking.rego
+++ b/rules/kubernetes/policies/general/manage_kubernetes_networking.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV056
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_kubernetes_rbac_resources.rego
+++ b/rules/kubernetes/policies/general/manage_kubernetes_rbac_resources.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV050
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_namespace_secrets.rego
+++ b/rules/kubernetes/policies/general/manage_namespace_secrets.rego
@@ -15,6 +15,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: role
 package builtin.kubernetes.KSV113
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_secrets.rego
+++ b/rules/kubernetes/policies/general/manage_secrets.rego
@@ -15,6 +15,8 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
 package builtin.kubernetes.KSV041
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/manage_webhook_configurations.rego
+++ b/rules/kubernetes/policies/general/manage_webhook_configurations.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: clusterrole
+#         - kind: role
 package builtin.kubernetes.KSV114
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/memory_not_limited.rego
+++ b/rules/kubernetes/policies/general/memory_not_limited.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV018
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/memory_requests_not_specified.rego
+++ b/rules/kubernetes/policies/general/memory_requests_not_specified.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV016
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/mounts_docker_socket.rego
+++ b/rules/kubernetes/policies/general/mounts_docker_socket.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV006
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/net_raw_capability.rego
+++ b/rules/kubernetes/policies/general/net_raw_capability.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV119
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/runs_with_GID_le_10000.rego
+++ b/rules/kubernetes/policies/general/runs_with_GID_le_10000.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV021
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/runs_with_UID_le_10000.rego
+++ b/rules/kubernetes/policies/general/runs_with_UID_le_10000.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV020
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/runs_with_a_root_primary_or_supplementary_GID.rego
+++ b/rules/kubernetes/policies/general/runs_with_a_root_primary_or_supplementary_GID.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV116
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/general/uses_image_tag_latest.rego
+++ b/rules/kubernetes/policies/general/uses_image_tag_latest.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV013
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/10_windows_host_process.rego
+++ b/rules/kubernetes/policies/pss/baseline/10_windows_host_process.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV103
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/11_seccomp_profile_unconfined.rego
+++ b/rules/kubernetes/policies/pss/baseline/11_seccomp_profile_unconfined.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV104
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/12_privileged_ports_binding.rego
+++ b/rules/kubernetes/policies/pss/baseline/12_privileged_ports_binding.rego
@@ -15,6 +15,16 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV117
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/1_host_ipc.rego
+++ b/rules/kubernetes/policies/pss/baseline/1_host_ipc.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV008
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/1_host_network.rego
+++ b/rules/kubernetes/policies/pss/baseline/1_host_network.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV009
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/1_host_pid.rego
+++ b/rules/kubernetes/policies/pss/baseline/1_host_pid.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV010
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/2_privileged.rego
+++ b/rules/kubernetes/policies/pss/baseline/2_privileged.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV017
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/3_specific_capabilities_added.rego
+++ b/rules/kubernetes/policies/pss/baseline/3_specific_capabilities_added.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV022
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/4_hostpath_volumes_mounted.rego
+++ b/rules/kubernetes/policies/pss/baseline/4_hostpath_volumes_mounted.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV023
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/5_access_to_host_ports.rego
+++ b/rules/kubernetes/policies/pss/baseline/5_access_to_host_ports.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV024
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/6_apparmor_policy_disabled.rego
+++ b/rules/kubernetes/policies/pss/baseline/6_apparmor_policy_disabled.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV002
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/7_selinux_custom_options_set.rego
+++ b/rules/kubernetes/policies/pss/baseline/7_selinux_custom_options_set.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV025
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/8_non_default_proc_masks_set.rego
+++ b/rules/kubernetes/policies/pss/baseline/8_non_default_proc_masks_set.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV027
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/baseline/9_unsafe_sysctl_options_set.rego
+++ b/rules/kubernetes/policies/pss/baseline/9_unsafe_sysctl_options_set.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV026
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/restricted/1_non_core_volume_types.rego
+++ b/rules/kubernetes/policies/pss/restricted/1_non_core_volume_types.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV028
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/restricted/2_can_elevate_its_own_privileges.rego
+++ b/rules/kubernetes/policies/pss/restricted/2_can_elevate_its_own_privileges.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV001
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/restricted/3_runs_as_root.rego
+++ b/rules/kubernetes/policies/pss/restricted/3_runs_as_root.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV012
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
+++ b/rules/kubernetes/policies/pss/restricted/5_runtime_default_seccomp_profile_not_set.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV030
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
+++ b/rules/kubernetes/policies/pss/restricted/7_Kubernetes_resource_with_disallowed_volumes_mounted.rego
@@ -15,6 +15,15 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: pod
+#         - kind: replicaset
+#         - kind: replicationcontroller
+#         - kind: deployment
+#         - kind: statefulset
+#         - kind: daemonset
+#         - kind: cronjob
+#         - kind: job
 package builtin.kubernetes.KSV121
 
 import data.lib.kubernetes

--- a/rules/kubernetes/policies/rolebinding/cluster_admin_role_is_only_used_where_required.rego
+++ b/rules/kubernetes/policies/rolebinding/cluster_admin_role_is_only_used_where_required.rego
@@ -15,6 +15,9 @@
 #   input:
 #     selector:
 #     - type: kubernetes
+#       subtypes:
+#         - kind: rolebinding
+#         - kind: clusterrolebinding
 package builtin.kubernetes.KSV111
 
 import data.lib.kubernetes


### PR DESCRIPTION

During a Kubernetes misconfiguration scan, we assess all policies, regardless of whether they are relevant to the resource being scanned.

By introducing subtype selectors, policies will now be assessed only if they are pertinent to the resources being scanned.

We have included subtype selectors only in the regos present in the commercial section.