### PR TITLE
ci: make the OPA installation more reliable

### DIFF
--- a/.github/actions/setup-opa/action.yaml
+++ b/.github/actions/setup-opa/action.yaml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         curl --retry 3 -L -o opa_linux_amd64 https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static
-        curl -L -o checksum https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64.sha256
+        curl -L -o checksum https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static.sha256
         sha256sum -c checksum
         chmod 755 ./opa_linux_amd64
         sudo mv ./opa_linux_amd64 /usr/local/bin/opa

--- a/.github/actions/setup-opa/action.yaml
+++ b/.github/actions/setup-opa/action.yaml
@@ -6,8 +6,8 @@ runs:
     - name: Setup OPA
       shell: bash
       run: |
-        curl --retry 3 -L -o opa_linux_amd64 https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static
+        curl --retry 3 -L -o opa_linux_amd64_static https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static
         curl -L -o checksum https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static.sha256
         sha256sum -c checksum
-        chmod 755 ./opa_linux_amd64
-        sudo mv ./opa_linux_amd64 /usr/local/bin/opa
+        chmod 755 ./opa_linux_amd64_static
+        sudo mv ./opa_linux_amd64_static /usr/local/bin/opa

--- a/.github/actions/setup-opa/action.yaml
+++ b/.github/actions/setup-opa/action.yaml
@@ -1,0 +1,13 @@
+name: Setup OPA CLI
+description: Setup OPA CLI
+runs:
+  using: composite
+  steps:
+    - name: Setup OPA
+      shell: bash
+      run: |
+        curl --retry 3 -L -o opa_linux_amd64 https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static
+        curl -L -o checksum https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64.sha256
+        sha256sum -c checksum
+        chmod 755 ./opa_linux_amd64
+        sudo mv ./opa_linux_amd64 /usr/local/bin/opa

--- a/.github/workflows/outdated-api-update.yaml
+++ b/.github/workflows/outdated-api-update.yaml
@@ -20,18 +20,15 @@ jobs:
         id: outdatedapi
         uses: fjogeleit/http-request-action@v1
         with:
-         url: 'https://raw.githubusercontent.com/aquasecurity/trivy-db-data/main/k8s/api/k8s-outdated-api.json'
-         method: 'GET'
+          url: "https://raw.githubusercontent.com/aquasecurity/trivy-db-data/main/k8s/api/k8s-outdated-api.json"
+          method: "GET"
       - name: embed outdatedapi-data with in dynamic rego policy
         env:
           OUTDATE_API_DATA: ${{ toJson(steps.outdatedapi.outputs.response) }}
         run: |
           make outdated-api-updated
       - name: Setup OPA
-        run: |
-          curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
-          chmod 755 ./opa
-          sudo mv ./opa /usr/local/bin
+        uses: ./.github/actions/setup-opa
       - name: OPA Format
         run: |
           opa fmt -w . | grep -v vendor || true
@@ -39,4 +36,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update outdated-api policy data
-          push_options: --force   
+          push_options: --force

--- a/.github/workflows/test-bundle.yml
+++ b/.github/workflows/test-bundle.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Build bundle
         run: make bundle
       - name: Setup OPA
-        run: |
-          curl -L -o opa_linux_amd64 https://openpolicyagent.org/downloads/latest/opa_linux_amd64
-          curl -L -o checksum https://openpolicyagent.org/downloads/latest/opa_linux_amd64.sha256
-          sha256sum -c checksum
-          chmod 755 ./opa_linux_amd64
-          sudo mv ./opa_linux_amd64 /usr/local/bin/opa
+        uses: ./.github/actions/setup-opa
       - name: Check bundle
         run: opa inspect bundle.tar.gz

--- a/.github/workflows/test-rego.yaml
+++ b/.github/workflows/test-rego.yaml
@@ -4,12 +4,12 @@ on:
     branches:
       - master
     paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
+      - "**/*.md"
+      - "LICENSE"
   pull_request:
     paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
+      - "**/*.md"
+      - "LICENSE"
   merge_group:
 env:
   GO_VERSION: "1.18"
@@ -21,12 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup OPA
-        run: |
-          curl -L -o opa_linux_amd64 https://openpolicyagent.org/downloads/latest/opa_linux_amd64
-          curl -L -o checksum https://openpolicyagent.org/downloads/latest/opa_linux_amd64.sha256
-          sha256sum -c checksum
-          chmod 755 ./opa_linux_amd64
-          sudo mv ./opa_linux_amd64 /usr/local/bin/opa
+        uses: ./.github/actions/setup-opa
       - name: OPA Format
         run: |
           files=$(opa fmt --list . | grep -v vendor || true)


### PR DESCRIPTION
I also took out the installation of OPA in a composite action

Close https://github.com/aquasecurity/defsec/issues/1440