### PR TITLE
chore: remove deprecated dead code linters from the rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,8 +39,6 @@ issues:
       text: "`.+(Good|Bad)Examples|Links|RemediationMarkdown` is unused"
       linters:
         - unused
-        - deadcode
-        - varcheck
 
     - path: pkg/scanners/terraform/parser/funcs/
       linters:


### PR DESCRIPTION
Deprecated dead code linters have been removed in https://github.com/aquasecurity/defsec/commit/deda78733569fa6a08693cdcf5ec15b89d4ae00a .
I removed them from the rules in the `golangci-lint` config

Close: https://github.com/aquasecurity/defsec/issues/1441