### PR TITLE
feat(cloud): add the DeletionProtection attribute to the RDS Cluster

### DIFF
--- a/avd_docs/aws/rds/AVD-AWS-0343/Terraform.md
+++ b/avd_docs/aws/rds/AVD-AWS-0343/Terraform.md
@@ -1,0 +1,9 @@
+
+Enable deletion protection at RDS clusters
+
+```hcl
+ resource "aws_rds_cluster" "good_example" {
+ 	deletion_protection = true
+ }
+
+```

--- a/avd_docs/aws/rds/AVD-AWS-0343/docs.md
+++ b/avd_docs/aws/rds/AVD-AWS-0343/docs.md
@@ -1,0 +1,12 @@
+
+Ensure deletion protection is enabled for RDS clusters.
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://docs.aws.amazon.com/config/latest/developerguide/rds-cluster-deletion-protection-enabled.html
+

--- a/internal/adapters/cloud/aws/rds/rds.go
+++ b/internal/adapters/cloud/aws/rds/rds.go
@@ -267,6 +267,7 @@ func (a *adapter) adaptCluster(dbCluster types.DBCluster) (*rds.Cluster, error) 
 		Engine:               defsecTypes.String(engine, dbClusterMetadata),
 		LatestRestorableTime: defsecTypes.TimeUnresolvable(dbClusterMetadata),
 		AvailabilityZones:    availabilityZones,
+		DeletionProtection:   defsecTypes.Bool(aws.ToBool(dbCluster.DeletionProtection), dbClusterMetadata),
 	}
 
 	return cluster, nil

--- a/internal/adapters/cloudformation/aws/rds/cluster.go
+++ b/internal/adapters/cloudformation/aws/rds/cluster.go
@@ -27,6 +27,7 @@ func getClusters(ctx parser.FileContext) (clusters map[string]rds.Cluster) {
 			PublicAccess:         defsecTypes.BoolDefault(false, clusterResource.Metadata()),
 			Engine:               defsecTypes.StringDefault(rds.EngineAurora, clusterResource.Metadata()),
 			LatestRestorableTime: defsecTypes.TimeUnresolvable(clusterResource.Metadata()),
+			DeletionProtection:   defsecTypes.BoolDefault(false, clusterResource.Metadata()),
 		}
 
 		if engineProp := clusterResource.GetProperty("Engine"); engineProp.IsString() {

--- a/internal/adapters/terraform/aws/rds/adapt.go
+++ b/internal/adapters/terraform/aws/rds/adapt.go
@@ -72,6 +72,7 @@ func getClusters(modules terraform.Modules) (clusters []rds.Cluster) {
 			PublicAccess:         defsecTypes.BoolDefault(false, defsecTypes.NewUnmanagedMetadata()),
 			Engine:               defsecTypes.StringUnresolvable(defsecTypes.NewUnmanagedMetadata()),
 			LatestRestorableTime: defsecTypes.TimeUnresolvable(defsecTypes.NewUnmanagedMetadata()),
+			DeletionProtection:   defsecTypes.BoolDefault(false, defsecTypes.NewUnmanagedMetadata()),
 		}
 		for _, orphan := range orphanResources {
 			orphanage.Instances = append(orphanage.Instances, adaptClusterInstance(orphan, modules))
@@ -224,6 +225,7 @@ func adaptCluster(resource *terraform.Block, modules terraform.Modules) (rds.Clu
 		Engine:                    resource.GetAttribute("engine").AsStringValueOrDefault(rds.EngineAurora, resource),
 		LatestRestorableTime:      defsecTypes.TimeUnresolvable(resource.GetMetadata()),
 		AvailabilityZones:         resource.GetAttribute("availability_zones").AsStringValueSliceOrEmpty(resource),
+		DeletionProtection:        resource.GetAttribute("deletion_protection").AsBoolValueOrDefault(false, resource),
 	}, ids
 }
 

--- a/internal/adapters/terraform/aws/rds/adapt_test.go
+++ b/internal/adapters/terraform/aws/rds/adapt_test.go
@@ -30,6 +30,7 @@ func Test_Adapt(t *testing.T) {
 				kms_key_id  = "kms_key_1"
 				storage_encrypted = true
 				replication_source_identifier = "arn-of-a-source-db-cluster"
+                deletion_protection = true
 			  }
 	
 			resource "aws_rds_cluster_instance" "example" {
@@ -121,6 +122,7 @@ func Test_Adapt(t *testing.T) {
 							defsecTypes.String("us-west-2b", defsecTypes.NewTestMetadata()),
 							defsecTypes.String("us-west-2c", defsecTypes.NewTestMetadata()),
 						},
+						DeletionProtection: defsecTypes.Bool(true, defsecTypes.NewTestMetadata()),
 					},
 				},
 				Classic: rds.Classic{

--- a/internal/adapters/terraform/aws/rds/adapt_test.go
+++ b/internal/adapters/terraform/aws/rds/adapt_test.go
@@ -30,7 +30,7 @@ func Test_Adapt(t *testing.T) {
 				kms_key_id  = "kms_key_1"
 				storage_encrypted = true
 				replication_source_identifier = "arn-of-a-source-db-cluster"
-                deletion_protection = true
+				deletion_protection = true
 			  }
 	
 			resource "aws_rds_cluster_instance" "example" {

--- a/pkg/providers/aws/rds/rds.go
+++ b/pkg/providers/aws/rds/rds.go
@@ -47,6 +47,7 @@ type Cluster struct {
 	Engine                    defsecTypes.StringValue
 	LatestRestorableTime      defsecTypes.TimeValue
 	AvailabilityZones         []defsecTypes.StringValue
+	DeletionProtection        defsecTypes.BoolValue
 }
 
 type Snapshots struct {

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -2398,6 +2398,10 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
         },
+        "deletionprotection": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.rds.Encryption"
+        },
         "instances": {
           "type": "array",
           "items": {

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -2390,6 +2390,10 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.IntValue"
         },
+        "deletionprotection": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.BoolValue"
+        },
         "encryption": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.rds.Encryption"
@@ -2397,10 +2401,6 @@
         "engine": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
-        },
-        "deletionprotection": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.rds.Encryption"
         },
         "instances": {
           "type": "array",

--- a/rules/cloud/policies/aws/iam/filter_iam_pass_role_test.rego
+++ b/rules/cloud/policies/aws/iam/filter_iam_pass_role_test.rego
@@ -5,6 +5,7 @@ test_with_allow_iam_pass_role {
 		"name": "policy_with_iam_pass_role",
 		"document": {"value": "{\"Version\":\"2012-10-17\",\"Id\":\"\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{},\"NotPrincipal\":{},\"Action\":[\"iam:PassRole\"],\"NotAction\":null,\"Resource\":[\"arn:aws:iam::193063503752:role/atc-node\"],\"NotResource\":null,\"Condition\":{}}]}"},
 	}]
+
 	r := deny with input as {"aws": {"iam": {"policies": policies}}}
 	count(r) == 1
 }
@@ -14,6 +15,7 @@ test_with_deny_iam_pass_role {
 		"name": "policy_with_iam_pass_role",
 		"document": {"value": "{\"Version\":\"2012-10-17\",\"Id\":\"\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Deny\",\"Principal\":{},\"NotPrincipal\":{},\"Action\":[\"iam:PassRole\"],\"NotAction\":null,\"Resource\":[\"arn:aws:iam::193063503752:role/atc-node\"],\"NotResource\":null,\"Condition\":{}}]}"},
 	}]
+
 	r := deny with input as {"aws": {"iam": {"policies": policies}}}
 	count(r) == 0
 }
@@ -23,6 +25,7 @@ test_with_no_iam_pass_role {
 		"name": "policy_without_iam_pass_role",
 		"document": {"value": "{\"Version\":\"2012-10-17\",\"Id\":\"\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{},\"NotPrincipal\":{},\"Action\":[\"s3:GetObject\"],\"NotAction\":null,\"Resource\":[\"arn:aws:s3:::examplebucket/*\"],\"NotResource\":null,\"Condition\":{}}]}"},
 	}]
+
 	r := deny with input as {"aws": {"iam": {"policies": policies}}}
 	count(r) == 0
 }

--- a/rules/cloud/policies/aws/rds/enable_cluster_deletion_protection.rego
+++ b/rules/cloud/policies/aws/rds/enable_cluster_deletion_protection.rego
@@ -1,6 +1,6 @@
 # METADATA
-# title: "RDS Deletion Protection Disabled"
-# description: "Ensure deletion protection is enabled for RDS database instances."
+# title: "RDS Cluster Deletion Protection Disabled"
+# description: "Ensure deletion protection is enabled for RDS clusters."
 # scope: package
 # schemas:
 # - input: schema["cloud"]

--- a/rules/cloud/policies/aws/rds/enable_cluster_deletion_protection.rego
+++ b/rules/cloud/policies/aws/rds/enable_cluster_deletion_protection.rego
@@ -1,0 +1,28 @@
+# METADATA
+# title: "RDS Deletion Protection Disabled"
+# description: "Ensure deletion protection is enabled for RDS database instances."
+# scope: package
+# schemas:
+# - input: schema["cloud"]
+# related_resources:
+# - https://docs.aws.amazon.com/config/latest/developerguide/rds-cluster-deletion-protection-enabled.html
+# custom:
+#   avd_id: AVD-AWS-0343
+#   provider: aws
+#   service: rds
+#   severity: MEDIUM
+#   short_code: enable-cluster-deletion-protection
+#   recommended_action: "Modify the RDS clusters to enable deletion protection."
+#   input:
+#     selector:
+#     - type: cloud
+#       subtypes:
+#         - service: rds
+#           provider: aws
+package builtin.aws.rds.aws0343
+
+deny[res] {
+	cluster := input.aws.rds.clusters[_]
+	not cluster.deletionprotection.value
+	res := result.new("Cluster does not have Deletion Protection enabled", cluster.deletionprotection)
+}

--- a/rules/cloud/policies/aws/rds/enable_cluster_deletion_protection_test.rego
+++ b/rules/cloud/policies/aws/rds/enable_cluster_deletion_protection_test.rego
@@ -1,0 +1,11 @@
+package builtin.aws.rds.aws0343
+
+test_detects_when_disabled {
+	r := deny with input as {"aws": {"rds": {"clusters": [{"deletionprotection": {"value": false}}]}}}
+	count(r) == 1
+}
+
+test_when_enabled {
+	r := deny with input as {"aws": {"rds": {"clusters": [{"deletionprotection": {"value": true}}]}}}
+	count(r) == 0
+}


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/trivy/issues/5112

## motivation

I want to avert some human mistakes in the RDS Cluster, but I can't detect them now.
( Now, I can only detect the RDS instance's deletionProtection. )

For example, the below codes are not working as intended.

```
deny[res] {
	cluster := input.aws.rds.clusters[_]
        instance := cluster.instances[_]
	not instance.deletionprotection.value
	res := result.new("Cluster does not have Deletion Protection enabled", instance.deletionprotection)
}
```

So, I would like to add the DeletionProtection attribute to the RDS Cluster.