### PR TITLE
fix(terraform): convert input variables to expected type

### DIFF
--- a/pkg/terraform/attribute.go
+++ b/pkg/terraform/attribute.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"reflect"
@@ -30,7 +29,7 @@ type Attribute struct {
 func (a *Attribute) DecodeVarType() (cty.Type, *typeexpr.Defaults, error) {
 	t, def, diag := typeexpr.TypeConstraintWithDefaults(a.hclAttribute.Expr)
 	if diag.HasErrors() {
-		return cty.NilType, nil, errors.Join(diag.Errs()...)
+		return cty.NilType, nil, diag
 	}
 	return t, def, nil
 }

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -604,7 +604,7 @@ module "something" {
 `,
 		"modules/a/main.tf": `
 variable "group" {
-    type = "string"
+    type = string
 }
 
 resource aws_iam_group_policy mfa {


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy/issues/4997

The problem was that defsec did not convert variables to the expected type, which prevented variables of type `set`, `map` or `object` from being used as an argument to [for_each](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each#the-for_each-meta-argument). This PR adds conversion of input variable values to the expected [type](https://developer.hashicorp.com/terraform/language/values/variables#type-constraints). 

Also, `defsec` will now take into account the default values that the [optional](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes) modifier sets if the value of a variable attribute is missing:

```tf
variable "policy_rules" {
  type = object({
    secure_tags = optional(map(object({
      session_matcher        = optional(string)
      priority               = number
      enabled                = optional(bool, true)
    })), {})
  })
}
```