### PR TITLE
fix(azure): Bump up `min_tls_value` for storage adapters

### DIFF
--- a/internal/adapters/terraform/azure/storage/adapt.go
+++ b/internal/adapters/terraform/azure/storage/adapt.go
@@ -128,7 +128,7 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 	}
 
 	minTLSVersionAttr := resource.GetAttribute("min_tls_version")
-	account.MinimumTLSVersion = minTLSVersionAttr.AsStringValueOrDefault("TLS1_0", resource)
+	account.MinimumTLSVersion = minTLSVersionAttr.AsStringValueOrDefault("TLS1_2", resource)
 	return account
 }
 


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/trivy/issues/4981