### PR TITLE
fix(terraform): do not scan local modules as root modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/testcontainers/testcontainers-go v0.22.0
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5
 )
 
@@ -238,7 +239,6 @@ require (
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/pkg/scanners/terraform/scanner.go
+++ b/pkg/scanners/terraform/scanner.go
@@ -10,23 +10,20 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aquasecurity/defsec/pkg/types"
-
-	"github.com/aquasecurity/defsec/pkg/framework"
+	"golang.org/x/exp/slices"
 
 	"github.com/aquasecurity/defsec/pkg/debug"
-
-	"github.com/aquasecurity/defsec/pkg/scanners/options"
-
+	"github.com/aquasecurity/defsec/pkg/extrafs"
+	"github.com/aquasecurity/defsec/pkg/framework"
 	"github.com/aquasecurity/defsec/pkg/rego"
+	"github.com/aquasecurity/defsec/pkg/scan"
 	"github.com/aquasecurity/defsec/pkg/scanners"
+	"github.com/aquasecurity/defsec/pkg/scanners/options"
 	"github.com/aquasecurity/defsec/pkg/scanners/terraform/executor"
 	"github.com/aquasecurity/defsec/pkg/scanners/terraform/parser"
 	"github.com/aquasecurity/defsec/pkg/scanners/terraform/parser/resolvers"
-
-	"github.com/aquasecurity/defsec/pkg/scan"
-
-	"github.com/aquasecurity/defsec/pkg/extrafs"
+	"github.com/aquasecurity/defsec/pkg/terraform"
+	"github.com/aquasecurity/defsec/pkg/types"
 )
 
 var _ scanners.FSScanner = (*Scanner)(nil)
@@ -168,6 +165,31 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	return regoScanner, nil
 }
 
+// terraformRootModule represents the module to be used as the root module for Terraform deployment.
+type terraformRootModule struct {
+	rootPath string
+	childs   terraform.Modules
+	fsMap    map[string]fs.FS
+}
+
+func excludeNonRootModules(modules []terraformRootModule) []terraformRootModule {
+	var result []terraformRootModule
+	var childPaths []string
+
+	for _, module := range modules {
+		childPaths = append(childPaths, module.childs.ChildModulesPaths()...)
+	}
+
+	for _, module := range modules {
+		// if the path of the root module matches the path of the child module,
+		// then we should not scan it
+		if !slices.Contains(childPaths, module.rootPath) {
+			result = append(result, module)
+		}
+	}
+	return result
+}
+
 func (s *Scanner) ScanFSWithMetrics(ctx context.Context, target fs.FS, dir string) (scan.Results, Metrics, error) {
 
 	var metrics Metrics
@@ -195,14 +217,12 @@ func (s *Scanner) ScanFSWithMetrics(ctx context.Context, target fs.FS, dir strin
 	var allResults scan.Results
 
 	// parse all root module directories
+	var rootModules []terraformRootModule
 	for _, dir := range rootDirs {
 
 		s.debug.Log("Scanning root module '%s'...", dir)
 
 		p := parser.New(target, "", s.parserOpt...)
-		s.execLock.RLock()
-		e := executor.New(s.executorOpt...)
-		s.execLock.RUnlock()
 
 		if err := p.ParseFS(ctx, dir); err != nil {
 			return nil, metrics, err
@@ -220,12 +240,25 @@ func (s *Scanner) ScanFSWithMetrics(ctx context.Context, target fs.FS, dir strin
 		metrics.Parser.Timings.DiskIODuration += parserMetrics.Timings.DiskIODuration
 		metrics.Parser.Timings.ParseDuration += parserMetrics.Timings.ParseDuration
 
-		results, execMetrics, err := e.Execute(modules)
+		p.GetFilesystemMap()
+		rootModules = append(rootModules, terraformRootModule{
+			rootPath: dir,
+			childs:   modules,
+			fsMap:    p.GetFilesystemMap(),
+		})
+	}
+
+	rootModules = excludeNonRootModules(rootModules)
+
+	for _, module := range rootModules {
+		s.execLock.RLock()
+		e := executor.New(s.executorOpt...)
+		s.execLock.RUnlock()
+		results, execMetrics, err := e.Execute(module.childs)
 		if err != nil {
 			return nil, metrics, err
 		}
 
-		fsMap := p.GetFilesystemMap()
 		for i, result := range results {
 			if result.Metadata().Range().GetFS() != nil {
 				continue
@@ -234,7 +267,7 @@ func (s *Scanner) ScanFSWithMetrics(ctx context.Context, target fs.FS, dir strin
 			if key == "" {
 				continue
 			}
-			if filesystem, ok := fsMap[key]; ok {
+			if filesystem, ok := module.fsMap[key]; ok {
 				override := scan.Results{
 					result,
 				}

--- a/pkg/scanners/terraform/scanner_test.go
+++ b/pkg/scanners/terraform/scanner_test.go
@@ -1007,7 +1007,7 @@ deny[res] {
 
 }
 
-func TestXxx(t *testing.T) {
+func Test_DoNotScanNonRootModules(t *testing.T) {
 	fs := testutil.CreateFS(t, map[string]string{
 		"/code/app1/main.tf": `
 module "s3" {

--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -11,6 +11,7 @@ type Module struct {
 	rootPath   string
 	modulePath string
 	ignores    Ignores
+	parent     *Module
 }
 
 func NewModule(rootPath string, modulePath string, blocks Blocks, ignores Ignores) *Module {
@@ -30,6 +31,10 @@ func NewModule(rootPath string, modulePath string, blocks Blocks, ignores Ignore
 		rootPath:   rootPath,
 		modulePath: modulePath,
 	}
+}
+
+func (c *Module) SetParent(parent *Module) {
+	c.parent = parent
 }
 
 func (c *Module) RootPath() string {

--- a/pkg/terraform/modules.go
+++ b/pkg/terraform/modules.go
@@ -8,6 +8,16 @@ import (
 
 type Modules []*Module
 
+func (m Modules) ChildModulesPaths() []string {
+	var result []string
+	for _, module := range m {
+		if module.parent != nil {
+			result = append(result, module.modulePath)
+		}
+	}
+	return result
+}
+
 type ResourceIDResolutions map[string]bool
 
 func (r ResourceIDResolutions) Resolve(id string) {


### PR DESCRIPTION
This PR fixes a bug when Trivy scans local modules as root modules. See https://github.com/aquasecurity/trivy/issues/4988.

Configuration example:

`main.tf`
```tf
module "main" {
  source      = "./modules/s3"
  versioning = "Enabled"
}
```

`modules/s3/main.tf`
```tf
variable "versioning" {
  type = string
}

resource "aws_s3_bucket" "main" {
  bucket = "test"
}

resource "aws_s3_bucket_versioning" "example" {
  bucket = aws_s3_bucket.main.id
  versioning_configuration {
    status = var.versioning
  }
}
```

Before:
```bash
trivy config . -f json | jq '.Results[] | .Misconfigurations | .[]?.Title'
2023-10-05T20:10:23.028+0700	INFO	Misconfiguration scanning is enabled
2023-10-05T20:10:24.956+0700	INFO	Detected config files: 3
"S3 Access block should block public ACL"
"S3 Access block should block public ACL"
"S3 Access block should block public policy"
"S3 Access block should block public policy"
"Unencrypted S3 bucket."
"Unencrypted S3 bucket."
"S3 Bucket Logging"
"S3 Bucket Logging"
"S3 Data should be versioned"
"S3 Access Block should Ignore Public Acl"
"S3 Access Block should Ignore Public Acl"
"S3 Access block should restrict public bucket to limit access"
"S3 Access block should restrict public bucket to limit access"
"S3 buckets should each define an aws_s3_bucket_public_access_block"
"S3 buckets should each define an aws_s3_bucket_public_access_block"
"S3 encryption should use Customer Managed Keys"
"S3 encryption should use Customer Managed Keys"
```

After:
```bash
2023-10-05T20:13:02.416+0700    INFO    Misconfiguration scanning is enabled
2023-10-05T20:13:02.839+0700    INFO    Detected config files: 2
"S3 Access block should block public ACL"
"S3 Access block should block public policy"
"Unencrypted S3 bucket."
"S3 Bucket Logging"
"S3 Access Block should Ignore Public Acl"
"S3 Access block should restrict public bucket to limit access"
"S3 buckets should each define an aws_s3_bucket_public_access_block"
"S3 encryption should use Customer Managed Keys"
```