### PR TITLE
fix(terraform): check if module is local

### DIFF
--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -12,9 +12,10 @@ type Module struct {
 	modulePath string
 	ignores    Ignores
 	parent     *Module
+	local      bool
 }
 
-func NewModule(rootPath string, modulePath string, blocks Blocks, ignores Ignores) *Module {
+func NewModule(rootPath string, modulePath string, blocks Blocks, ignores Ignores, local bool) *Module {
 
 	blockMap := make(map[string]Blocks)
 
@@ -30,6 +31,7 @@ func NewModule(rootPath string, modulePath string, blocks Blocks, ignores Ignore
 		blockMap:   blockMap,
 		rootPath:   rootPath,
 		modulePath: modulePath,
+		local:      local,
 	}
 }
 

--- a/pkg/terraform/modules.go
+++ b/pkg/terraform/modules.go
@@ -11,7 +11,7 @@ type Modules []*Module
 func (m Modules) ChildModulesPaths() []string {
 	var result []string
 	for _, module := range m {
-		if module.parent != nil {
+		if module.parent != nil && module.local {
 			result = append(result, module.modulePath)
 		}
 	}


### PR DESCRIPTION
To filter non-root modules, we should only check paths of local modules.

See https://github.com/aquasecurity/trivy/issues/5414