### PR TITLE
fix: remove PodSecurityPolicy field

### DIFF
--- a/pkg/providers/google/gke/gke.go
+++ b/pkg/providers/google/gke/gke.go
@@ -17,7 +17,6 @@ type Cluster struct {
 	PrivateCluster           PrivateCluster
 	LoggingService           defsecTypes.StringValue
 	MonitoringService        defsecTypes.StringValue
-	PodSecurityPolicy        PodSecurityPolicy
 	MasterAuth               MasterAuth
 	NodeConfig               NodeConfig
 	EnableShieldedNodes      defsecTypes.BoolValue
@@ -50,11 +49,6 @@ type MasterAuth struct {
 type ClientCertificate struct {
 	Metadata         defsecTypes.Metadata
 	IssueCertificate defsecTypes.BoolValue
-}
-
-type PodSecurityPolicy struct {
-	Metadata defsecTypes.Metadata
-	Enabled  defsecTypes.BoolValue
 }
 
 type PrivateCluster struct {


### PR DESCRIPTION
PodSecurityPolicy has been [removed](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs). 