### PR TITLE
refactor(google): update DNSManagedZone resource structure

### DIFF
--- a/pkg/providers/google/dns/dns.go
+++ b/pkg/providers/google/dns/dns.go
@@ -21,16 +21,11 @@ func (m ManagedZone) IsPrivate() bool {
 type DNSSec struct {
 	Metadata        defsecTypes.Metadata
 	Enabled         defsecTypes.BoolValue
-	DefaultKeySpecs KeySpecs
+	DefaultKeySpecs []KeySpecs
 }
 
 type KeySpecs struct {
-	Metadata       defsecTypes.Metadata
-	KeySigningKey  Key
-	ZoneSigningKey Key
-}
-
-type Key struct {
 	Metadata  defsecTypes.Metadata
 	Algorithm defsecTypes.StringValue
+	KeyType   defsecTypes.StringValue
 }


### PR DESCRIPTION
DefaultKeySpecs is a list https://cloud.google.com/config-connector/docs/reference/resource-docs/dns/dnsmanagedzone#schema