### PR TITLE
feat(digitalocean): support for redirect_http_to_https for load balancer

### DIFF
--- a/pkg/providers/digitalocean/compute/compute.go
+++ b/pkg/providers/digitalocean/compute/compute.go
@@ -24,8 +24,9 @@ type KubernetesCluster struct {
 }
 
 type LoadBalancer struct {
-	Metadata        defsecTypes.Metadata
-	ForwardingRules []ForwardingRule
+	Metadata            defsecTypes.Metadata
+	ForwardingRules     []ForwardingRule
+	RedirectHttpToHttps defsecTypes.BoolValue
 }
 
 type ForwardingRule struct {


### PR DESCRIPTION
`redirect_http_to_https` is required for  https://github.com/aquasecurity/trivy/issues/5111