### PR TITLE
feat(ec2): name support for the launch template

### DIFF
--- a/pkg/providers/aws/ec2/launch.go
+++ b/pkg/providers/aws/ec2/launch.go
@@ -16,6 +16,7 @@ type LaunchConfiguration struct {
 
 type LaunchTemplate struct {
 	Metadata defsecTypes.Metadata
+	Name     defsecTypes.StringValue
 	Instance
 }
 

--- a/pkg/terraform/presets.go
+++ b/pkg/terraform/presets.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -22,6 +23,9 @@ func createPresetValues(b *Block) map[string]cty.Value {
 	switch b.TypeLabel() {
 	case "aws_iam_policy_document":
 		presets["json"] = cty.StringVal(b.ID())
+	// If the user leaves the name blank, Terraform will automatically generate a unique name
+	case "aws_launch_template":
+		presets["name"] = cty.StringVal(uuid.New().String())
 	}
 
 	return presets


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy/issues/5793