### PR TITLE
fix(terraform): fix reference extraction from TupleConsExpr

### DIFF
--- a/pkg/terraform/attribute.go
+++ b/pkg/terraform/attribute.go
@@ -987,8 +987,10 @@ func (a *Attribute) referencesFromExpression(expression hcl.Expression) []*Refer
 			refs = append(refs, ref)
 		}
 	case *hclsyntax.TupleConsExpr:
-		if ref, err := createDotReferenceFromTraversal(a.module, t.Variables()...); err == nil {
-			refs = append(refs, ref)
+		for _, v := range t.Variables() {
+			if ref, err := createDotReferenceFromTraversal(a.module, v); err == nil {
+				refs = append(refs, ref)
+			}
 		}
 	case *hclsyntax.RelativeTraversalExpr:
 		switch s := t.Source.(type) {


### PR DESCRIPTION
The [AllReferences](https://github.com/aquasecurity/defsec/blob/4ab1fa82def6e743d722418f3db90b554622d1f9/pkg/terraform/attribute.go#L946) method of the `ssh_keys` attribute returns only 1 reference to a block, but must return 2. The attribute expression is [TupleConsExpr](https://github.com/hashicorp/hcl/blob/v2.19.1/hclsyntax/expression.go#L1035), which represents a list or set of expressions that can reference another block.  This PR fixes this and extracts references from each `TupleConsExpr` expression.

Sample config:
```tf
data "digitalocean_ssh_key" "first" {
  name = "mikhalych_deploy_key"
}

data "digitalocean_ssh_key" "second" {
  name = "d.lukshto-deploy-key"
}

resource "digitalocean_droplet" "this" {
  image              = "ubuntu-20-04-x64"
  name               = "test"
  region             = var.region
  size               = "g-2vcpu-8gb"
  private_networking = true
  ssh_keys = [
    data.digitalocean_ssh_key.first.id,
    data.digitalocean_ssh_key.second.id,
  ]
}
```