### PR TITLE
feat: add support for AWS VPN `client_login_banner_options`

### DIFF
--- a/avd_docs/aws/vpn/AVD-AWS-0345/Terraform.md
+++ b/avd_docs/aws/vpn/AVD-AWS-0345/Terraform.md
@@ -1,0 +1,13 @@
+
+Enable VPN login banner options
+
+```hcl
+resource "aws_ec2_client_vpn_endpoint" "good_example" {
+    client_login_banner_options = "demo-configuration"
+}
+ 
+```
+
+#### Remediation Links
+ - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_endpoint#client_login_banner_options
+

--- a/avd_docs/aws/vpn/AVD-AWS-0345/docs.md
+++ b/avd_docs/aws/vpn/AVD-AWS-0345/docs.md
@@ -1,0 +1,11 @@
+
+AWS Client VPN does not enable login banner by default. To ensure that you are able to accurately audit the usage of your Neptune instance you should enable client banner messages.
+
+### Impact
+System use banner message is not implemented.
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html

--- a/internal/adapters/terraform/aws/vpn/adapt.go
+++ b/internal/adapters/terraform/aws/vpn/adapt.go
@@ -24,7 +24,7 @@ func adaptVPNs(modules terraform.Modules) []vpn.VpnEndpoint {
 
 func adaptVpn(resource *terraform.Block) vpn.VpnEndpoint {
 	vpnEndpoint := vpn.VpnEndpoint{
-		Metadata: resource.GetMetadata(),
+		Metadata:      resource.GetMetadata(),
 		BannerOptions: defsecTypes.StringDefault("", resource.GetMetadata()),
 	}
 

--- a/internal/adapters/terraform/aws/vpn/adapt.go
+++ b/internal/adapters/terraform/aws/vpn/adapt.go
@@ -1,0 +1,37 @@
+package vpn
+
+import (
+	"github.com/aquasecurity/defsec/pkg/providers/aws/vpn"
+	"github.com/aquasecurity/defsec/pkg/terraform"
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+)
+
+type adapter struct {
+	modules terraform.Modules
+	vpnMap  map[string]*vpn.VPN
+}
+
+func (a *adapter) adaptVPNs() []vpn.VPN {
+	for _, block := range a.modules.GetResourcesByType("aws_ec2_client_vpn_endpoint") {
+		vpn := &vpn.VPN{
+			BannerOptions: block.GetAttribute("client_login_banner_options").AsStringValueOrDefault("", block),
+		}
+
+		a.vpnMap[block.ID()] = vpn
+	}
+
+	var vpns []vpn.VPN
+	for _, vpn := range a.vpnMap {
+		vpns = append(vpns, *vpn)
+	}
+
+	return vpns
+}
+
+func getBannerOptions (b *terraform.Block, a *adapter) defsecTypes.StringValue {
+	var options defsecTypes.StringValue
+	for _, r := range a.modules.GetReferencingResources(b, "aws_ec2_client_vpn_endpoint", "client_login_banner_options") {
+		options = r.GetAttribute("client_login_banner_options").AsStringValueOrDefault("", r)
+	}
+	return options
+}

--- a/internal/adapters/terraform/aws/vpn/adapt_test.go
+++ b/internal/adapters/terraform/aws/vpn/adapt_test.go
@@ -16,9 +16,9 @@ import (
 
 func Test_adaptVpnEndpoint(t *testing.T) {
 	tests := []struct {
-		name	string
+		name      string
 		terraform string
-		expected vpn.VpnEndpoint
+		expected  vpn.VpnEndpoint
 	}{
 		{
 			name: "configured",
@@ -28,7 +28,7 @@ func Test_adaptVpnEndpoint(t *testing.T) {
 			}
 `,
 			expected: vpn.VpnEndpoint{
-				Metadata: defsecTypes.NewTestMetadata(),
+				Metadata:      defsecTypes.NewTestMetadata(),
 				BannerOptions: defsecTypes.String("test-configuration", defsecTypes.NewTestMetadata()),
 			},
 		},
@@ -39,7 +39,7 @@ func Test_adaptVpnEndpoint(t *testing.T) {
 			}
 `,
 			expected: vpn.VpnEndpoint{
-				Metadata: defsecTypes.NewTestMetadata(),
+				Metadata:      defsecTypes.NewTestMetadata(),
 				BannerOptions: defsecTypes.String("", defsecTypes.NewTestMetadata()),
 			},
 		},
@@ -64,7 +64,7 @@ func TestLines(t *testing.T) {
 
 	require.Len(t, adapted.Vpns, 1)
 	vpn := adapted.Vpns[0]
-	
+
 	assert.Equal(t, 2, vpn.Metadata.Range().GetStartLine())
 	assert.Equal(t, 4, vpn.Metadata.Range().GetEndLine())
 

--- a/internal/adapters/terraform/aws/vpn/adapt_test.go
+++ b/internal/adapters/terraform/aws/vpn/adapt_test.go
@@ -1,0 +1,73 @@
+package vpn
+
+import (
+	"testing"
+
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/providers/aws/vpn"
+
+	"github.com/aquasecurity/defsec/internal/adapters/terraform/tftestutil"
+
+	"github.com/aquasecurity/defsec/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_adaptVpnEndpoint(t *testing.T) {
+	tests := []struct {
+		name	string
+		terraform string
+		expected vpn.VpnEndpoint
+	}{
+		{
+			name: "configured",
+			terraform: `
+			resource "aws_ec2_client_vpn_endpoint" "example" {
+				client_login_banner_options		= "test-configuration"
+			}
+`,
+			expected: vpn.VpnEndpoint{
+				Metadata: defsecTypes.NewTestMetadata(),
+				BannerOptions: defsecTypes.String("test-configuration", defsecTypes.NewTestMetadata()),
+			},
+		},
+		{
+			name: "defaults",
+			terraform: `
+			resource "aws_ec2_client_vpn_endpoint" "example" {
+			}
+`,
+			expected: vpn.VpnEndpoint{
+				Metadata: defsecTypes.NewTestMetadata(),
+				BannerOptions: defsecTypes.String("", defsecTypes.NewTestMetadata()),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules := tftestutil.CreateModulesFromSource(t, test.terraform, ".tf")
+			adapted := adaptVpn(modules.GetBlocks()[0])
+			testutil.AssertDefsecEqual(t, test.expected, adapted)
+		})
+	}
+}
+
+func TestLines(t *testing.T) {
+	src := `
+	resource "aws_ec2_client_vpn_endpoint" "example" {
+		client_login_banner_options		= "test-configuration"
+	}`
+	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
+	adapted := Adapt(modules)
+
+	require.Len(t, adapted.Vpns, 1)
+	vpn := adapted.Vpns[0]
+	
+	assert.Equal(t, 2, vpn.Metadata.Range().GetStartLine())
+	assert.Equal(t, 4, vpn.Metadata.Range().GetEndLine())
+
+	assert.Equal(t, 3, vpn.BannerOptions.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 3, vpn.BannerOptions.GetMetadata().Range().GetEndLine())
+}

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -34,6 +34,7 @@ import (
 	"github.com/aquasecurity/defsec/pkg/providers/aws/sns"
 	"github.com/aquasecurity/defsec/pkg/providers/aws/sqs"
 	"github.com/aquasecurity/defsec/pkg/providers/aws/ssm"
+	"github.com/aquasecurity/defsec/pkg/providers/aws/vpn"
 	"github.com/aquasecurity/defsec/pkg/providers/aws/workspaces"
 )
 
@@ -71,5 +72,6 @@ type AWS struct {
 	SNS            sns.SNS
 	SQS            sqs.SQS
 	SSM            ssm.SSM
+	VPN			   vpn.VPN
 	WorkSpaces     workspaces.WorkSpaces
 }

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -72,6 +72,6 @@ type AWS struct {
 	SNS            sns.SNS
 	SQS            sqs.SQS
 	SSM            ssm.SSM
-	VPN			   vpn.ClientVpn
+	VPN            vpn.ClientVpn
 	WorkSpaces     workspaces.WorkSpaces
 }

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -72,6 +72,6 @@ type AWS struct {
 	SNS            sns.SNS
 	SQS            sqs.SQS
 	SSM            ssm.SSM
-	VPN			   vpn.VPN
+	VPN			   vpn.ClientVpn
 	WorkSpaces     workspaces.WorkSpaces
 }

--- a/pkg/providers/aws/vpn/vpn.go
+++ b/pkg/providers/aws/vpn/vpn.go
@@ -1,0 +1,9 @@
+package vpn
+
+import (
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+)
+
+type VPN struct {
+	BannerOptions defsecTypes.StringValue
+}

--- a/pkg/providers/aws/vpn/vpn.go
+++ b/pkg/providers/aws/vpn/vpn.go
@@ -9,6 +9,6 @@ type ClientVpn struct {
 }
 
 type VpnEndpoint struct {
-	Metadata 		defsecTypes.Metadata
-	BannerOptions	defsecTypes.StringValue
+	Metadata      defsecTypes.Metadata
+	BannerOptions defsecTypes.StringValue
 }

--- a/pkg/providers/aws/vpn/vpn.go
+++ b/pkg/providers/aws/vpn/vpn.go
@@ -4,6 +4,11 @@ import (
 	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
 )
 
-type VPN struct {
-	BannerOptions defsecTypes.StringValue
+type ClientVpn struct {
+	Vpns []VpnEndpoint
+}
+
+type VpnEndpoint struct {
+	Metadata 		defsecTypes.Metadata
+	BannerOptions	defsecTypes.StringValue
 }

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -178,6 +178,10 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.ssm.SSM"
         },
+        "vpn": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.vpn.ClientVpn"
+        },
         "workspaces": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.workspaces.WorkSpaces"
@@ -3364,6 +3368,27 @@
       "type": "object",
       "properties": {
         "kmskeyid": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
+        }
+      }
+    },
+    "github.com.aquasecurity.defsec.pkg.providers.aws.vpn.ClientVpn": {
+      "type": "object",
+      "properties": {
+        "vpns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.providers.aws.vpn.VpnEndpoint"
+          }
+        }
+      }
+    },
+    "github.com.aquasecurity.defsec.pkg.providers.aws.vpn.VpnEndpoint": {
+      "type": "object",
+      "properties": {
+        "banneroptions": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.defsec.pkg.types.StringValue"
         }

--- a/rules/cloud/policies/aws/vpn/client_login_banner_options.go
+++ b/rules/cloud/policies/aws/vpn/client_login_banner_options.go
@@ -1,0 +1,45 @@
+package vpn
+
+import (
+	"github.com/aquasecurity/defsec/internal/rules"
+	"github.com/aquasecurity/defsec/pkg/providers"
+	"github.com/aquasecurity/defsec/pkg/scan"
+	"github.com/aquasecurity/defsec/pkg/severity"
+	"github.com/aquasecurity/defsec/pkg/state"
+)
+
+var CheckClientLoginBannerOptions = rules.Register(
+	scan.Rule{
+		AVDID:       "AVD-AWS-0345",
+		Provider:    providers.AWSProvider,
+		Service:     "vpn",
+		ShortCode:   "client_login_banner_options",
+		Summary:     "Client VPN should display login banner messages",
+		Impact:      "Missing client login banners or messages will fail an audit",
+		Resolution:  "Enable client login banner messages",
+		Explanation: `System use notifications can be implemented using messages or warning banners displayed before individuals log in to systems`,
+		Links: []string{
+			"https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html",
+		},
+		Terraform: &scan.EngineMetadata{
+			GoodExamples:        terraformCheckClientLoginBannerOptionsGoodExamples,
+			BadExamples:         terraformCheckClientLoginBannerOptionsBadExamples,
+			Links:               terraformCheckClientLoginBannerOptionsLinks,
+			RemediationMarkdown: terraformCheckClientLoginBannerOptionsRemediationMarkdown,
+		},
+		Severity: severity.High,
+	},
+	func(s *state.State) (results scan.Results) {
+		for _, vpn := range s.AWS.VPN.Vpns {
+			if vpn.BannerOptions.IsEmpty() {
+				results.Add(
+					"VPN does not display client login banner message.",
+					vpn.BannerOptions,
+				)
+			} else {
+				results.AddPassed(&vpn)
+			}
+		}
+		return
+	},
+)

--- a/rules/cloud/policies/aws/vpn/client_login_banner_options.tf.go
+++ b/rules/cloud/policies/aws/vpn/client_login_banner_options.tf.go
@@ -1,0 +1,23 @@
+package vpn
+
+var terraformCheckClientLoginBannerOptionsGoodExamples = []string{
+	`
+resource "aws_ec2_client_vpn_endpoint" "good_example" {
+	client_login_banner_options		= "test-configuration"
+}
+ `,
+}
+
+var terraformCheckClientLoginBannerOptionsBadExamples = []string{
+	`
+resource "aws_ec2_client_vpn_endpoint" "bad_example" {
+	client_login_banner_options		= ""
+}
+`,
+}
+
+var terraformCheckClientLoginBannerOptionsLinks = []string{
+	`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_endpoint#client_login_banner_options`,
+}
+
+var terraformCheckClientLoginBannerOptionsRemediationMarkdown = ``

--- a/rules/cloud/policies/aws/vpn/client_login_banner_options_test.go
+++ b/rules/cloud/policies/aws/vpn/client_login_banner_options_test.go
@@ -1,0 +1,65 @@
+package vpn
+
+import (
+	"testing"
+
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+
+	"github.com/aquasecurity/defsec/pkg/state"
+
+	"github.com/aquasecurity/defsec/pkg/providers/aws/vpn"
+	"github.com/aquasecurity/defsec/pkg/scan"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckClientLoginBannerOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    vpn.ClientVpn
+		expected bool
+	}{
+		{
+			name: "VPN client missing login banner",
+			input: vpn.ClientVpn{
+				Vpns: []vpn.VpnEndpoint{
+					{
+						Metadata:      defsecTypes.NewTestMetadata(),
+						BannerOptions: defsecTypes.String("", defsecTypes.NewTestMetadata()),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "VPN client displays login banner",
+			input: vpn.ClientVpn{
+				Vpns: []vpn.VpnEndpoint{
+					{
+						Metadata:      defsecTypes.NewTestMetadata(),
+						BannerOptions: defsecTypes.String("banner-message", defsecTypes.NewTestMetadata()),
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var testState state.State
+			testState.AWS.VPN = test.input
+			results := CheckClientLoginBannerOptions.Evaluate(&testState)
+			var found bool
+			for _, result := range results {
+				if result.Status() == scan.StatusFailed && result.Rule().LongID() == CheckClientLoginBannerOptions.Rule().LongID() {
+					found = true
+				}
+				if test.expected {
+					assert.True(t, found, "Rule should have been found")
+				} else {
+					assert.False(t, found, "Rule should not have been found")
+				}
+			}
+		})
+	}
+}

--- a/test/loader_test.go
+++ b/test/loader_test.go
@@ -16,7 +16,7 @@ func Test_loader_returns_expected_providers(t *testing.T) {
 
 func Test_load_returns_expected_services(t *testing.T) {
 	services := rules.GetProviderServiceNames("aws")
-	assert.Len(t, services, 33)
+	assert.Len(t, services, 34)
 }
 
 func Test_load_returns_expected_service_checks(t *testing.T) {


### PR DESCRIPTION
in support of https://github.com/aquasecurity/trivy/issues/5863, adding functionality to support the handling of the Terraform resource `aws_ec2_client_vpn_endpoint` and checks for missing `client_login_banner_options` argument.