### PR TITLE
fix(iam): pass all document metadata fields to rego

### DIFF
--- a/pkg/providers/aws/iam/iam.go
+++ b/pkg/providers/aws/iam/iam.go
@@ -36,15 +36,23 @@ type Document struct {
 func (d Document) ToRego() interface{} {
 	m := d.Metadata
 	doc, _ := d.Parsed.MarshalJSON()
-	return map[string]interface{}{
-		"filepath":  m.Range().GetFilename(),
-		"startline": m.Range().GetStartLine(),
-		"endline":   m.Range().GetEndLine(),
-		"managed":   m.IsManaged(),
-		"explicit":  m.IsExplicit(),
-		"value":     string(doc),
-		"fskey":     defsecTypes.CreateFSKey(m.Range().GetFS()),
+	input := map[string]interface{}{
+		"filepath":     m.Range().GetFilename(),
+		"startline":    m.Range().GetStartLine(),
+		"endline":      m.Range().GetEndLine(),
+		"managed":      m.IsManaged(),
+		"explicit":     m.IsExplicit(),
+		"value":        string(doc),
+		"sourceprefix": m.Range().GetSourcePrefix(),
+		"fskey":        defsecTypes.CreateFSKey(m.Range().GetFS()),
+		"resource":     m.Reference(),
 	}
+
+	if m.Parent() != nil {
+		input["parent"] = m.Parent().ToRego()
+	}
+
+	return input
 }
 
 type Group struct {

--- a/pkg/rego/schemas/cloud.json
+++ b/pkg/rego/schemas/cloud.json
@@ -2159,6 +2159,12 @@
         "managed": {
           "type": "boolean"
         },
+        "resource": {
+          "type": "string"
+        },
+        "sourceprefix": {
+          "type": "string"
+        },
         "startline": {
           "type": "integer"
         },


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy/issues/5955

The `sourceprefix` field is required to check that the module is remote.