### PR TITLE
fix(terraform): hcl object expressions to return references

### DIFF
--- a/pkg/terraform/attribute.go
+++ b/pkg/terraform/attribute.go
@@ -962,6 +962,10 @@ func (a *Attribute) AllReferences(blocks ...*Block) []*Reference {
 func (a *Attribute) referencesFromExpression(expression hcl.Expression) []*Reference {
 	var refs []*Reference
 	switch t := expression.(type) {
+	case *hclsyntax.ObjectConsExpr:
+		for _, item := range t.Items {
+			refs = append(refs, a.referencesFromExpression(item.ValueExpr)...)
+		}
 	case *hclsyntax.ConditionalExpr:
 		if ref, err := createDotReferenceFromTraversal(a.module, t.TrueResult.Variables()...); err == nil {
 			refs = append(refs, ref)

--- a/pkg/terraform/attribute_test.go
+++ b/pkg/terraform/attribute_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/defsec/pkg/terraform/context"
-	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+	"github.com/aquasecurity/defsec/pkg/types"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
@@ -17,6 +17,10 @@ func Test_AllReferences(t *testing.T) {
 	}{
 		{
 			input: "42", // literal
+			refs:  []string{},
+		},
+		{
+			input: "5 == 5", // comparison
 			refs:  []string{},
 		},
 		{
@@ -35,6 +39,10 @@ func Test_AllReferences(t *testing.T) {
 			input: `{x = 1, y = data.aws_ami.ubuntu.most_recent}`,
 			refs:  []string{"data.aws_ami.ubuntu.most_recent"},
 		},
+		{
+			input: `{foo = 1 == 1 ? true : data.aws_ami.ubuntu.most_recent}`,
+			refs:  []string{"data.aws_ami.ubuntu.most_recent"},
+		},
 	}
 
 	for _, test := range cases {
@@ -51,7 +59,7 @@ func Test_AllReferences(t *testing.T) {
 				Expr:      exp,
 				Range:     hcl.Range{},
 				NameRange: hcl.Range{},
-			}, ctx, "", defsecTypes.Metadata{}, Reference{}, "", nil)
+			}, ctx, "", types.Metadata{}, Reference{}, "", nil)
 
 			refs := a.AllReferences()
 			humanRefs := make([]string, 0, len(refs))

--- a/pkg/terraform/attribute_test.go
+++ b/pkg/terraform/attribute_test.go
@@ -1,0 +1,65 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/terraform/context"
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AllReferences(t *testing.T) {
+	cases := []struct {
+		input string
+		refs  []string
+	}{
+		{
+			input: "42", // literal
+			refs:  []string{},
+		},
+		{
+			input: "var.foo",
+			refs:  []string{"variable.foo"},
+		},
+		{
+			input: "resource.aws_instance.id",
+			refs:  []string{"aws_instance.id"},
+		},
+		{
+			input: "data.aws_ami.ubuntu.most_recent",
+			refs:  []string{"data.aws_ami.ubuntu.most_recent"},
+		},
+		{
+			input: `{x = 1, y = data.aws_ami.ubuntu.most_recent}`,
+			refs:  []string{"data.aws_ami.ubuntu.most_recent"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.input, func(t *testing.T) {
+			ctx := context.NewContext(&hcl.EvalContext{}, nil)
+
+			exp, diags := hclsyntax.ParseExpression([]byte(test.input), "", hcl.Pos{Line: 1, Column: 1})
+			if diags != nil && diags.HasErrors() {
+				t.Fatal(diags.Error())
+			}
+
+			a := NewAttribute(&hcl.Attribute{
+				Name:      "test",
+				Expr:      exp,
+				Range:     hcl.Range{},
+				NameRange: hcl.Range{},
+			}, ctx, "", defsecTypes.Metadata{}, Reference{}, "", nil)
+
+			refs := a.AllReferences()
+			humanRefs := make([]string, 0, len(refs))
+			for _, ref := range refs {
+				humanRefs = append(humanRefs, ref.HumanReadable())
+			}
+
+			require.ElementsMatch(t, test.refs, humanRefs)
+		})
+	}
+}


### PR DESCRIPTION
References included in hcl objects should be returned from 'Attribute.AllReferences()'. Traverse the object fields recursively to locate references.